### PR TITLE
chore: silent errors change empty string to "Error"

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -71,8 +71,8 @@ describe('listhen', () => {
   })
 
   test('silent errors', async () => {
-    clipboardy.write.mockImplementationOnce(() => Promise.reject(new Error('')))
-    open.mockImplementationOnce(() => Promise.reject(new Error('')))
+    clipboardy.write.mockImplementationOnce(() => Promise.reject(new Error('Error')))
+    open.mockImplementationOnce(() => Promise.reject(new Error('Error')))
     listener = await listen(handle, { isTest: false, clipboard: true, open: true })
   })
 


### PR DESCRIPTION
`new Error('')` make an error by
```
Error message should not be an empty string. `eslintunicorn/error-message`
```

I changed empty string to plain "Error".