### PR TITLE
fix: `host` option name

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,15 @@ listen(app)
 
 ### `port`
 
-- Default: `process.env.PORT` or 3000 or memorized random (see [get-port-please](https://github.com/unjs/get-port-please))
+- Default: `process.env.PORT || 3000` or memorized random (see [get-port-please](https://github.com/unjs/get-port-please))
 
 Port to listen.
+
+### host
+
+- Default: `process.env.HOST || '0.0.0.0'`
+
+Host to listen on.
 
 ### `https`
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint": "latest",
     "jest": "latest",
     "jiti": "latest",
+    "ohmyfetch": "^0.2.0",
     "siroc": "latest",
     "standard-version": "latest",
     "ts-jest": "latest",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,8 +21,8 @@ export interface CertificateInput {
 
 export interface ListenOptions {
   name: string
-  port?: GetPortInput,
-  hostname?: string,
+  port?: GetPortInput
+  host?: string
   https?: boolean
   selfsigned?: SelfsignedOptions
   showURL: boolean
@@ -46,7 +46,7 @@ export interface Listener {
 export async function listen (handle: http.RequestListener, opts: Partial<ListenOptions> = {}): Promise<Listener> {
   opts = {
     port: process.env.PORT || 3000,
-    hostname: process.env.HOST || '0.0.0.0',
+    host: process.env.HOST || '0.0.0.0',
     showURL: true,
     baseURL: '/',
     open: false,
@@ -71,8 +71,8 @@ export async function listen (handle: http.RequestListener, opts: Partial<Listen
   let server: http.Server | https.Server
   let url: string
 
-  const isExternal = opts.hostname === '0.0.0.0'
-  const displayHost = isExternal ? 'localhost' : opts.hostname
+  const isExternal = opts.host === '0.0.0.0'
+  const displayHost = isExternal ? 'localhost' : opts.host
 
   if (opts.https) {
     const { key, cert } = opts.certificate ? await resolveCert(opts.certificate) : await getSelfSignedCert(opts.selfsigned)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,8 @@
 // @ts-nocheck
 import './setup'
 import { resolve } from 'path'
-import { listen } from '../src'
+import { $fetch } from 'ohmyfetch/node'
+import { listen, Listener } from '../src'
 
 jest.mock('clipboardy')
 const clipboardy = require('clipboardy')
@@ -19,7 +20,7 @@ function handle (req, res) {
 }
 
 describe('listhen', () => {
-  let listener
+  let listener: Listener
 
   afterEach(async () => {
     if (listener) {
@@ -31,6 +32,15 @@ describe('listhen', () => {
   test('listen (no args)', async () => {
     listener = await listen(handle)
     expect(listener.url.startsWith('http://')).toBe(true)
+  })
+
+  test('listen (host)', async () => {
+    listener = await listen(handle, {
+      host: '127.0.0.1'
+    })
+    const response = await $fetch<string>(listener.url + 'test')
+    expect(listener.url).toContain('127.0.0.1')
+    expect(response).toEqual('/test')
   })
 
   test('listen (http)', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1855,6 +1855,11 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
+destr@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/destr/-/destr-1.1.0.tgz#2da6add6ba71e04fd0abfb1e642d4f6763235095"
+  integrity sha512-Ev/sqS5AzzDwlpor/5wFCDu0dYMQu/0x2D6XfAsQ0E7uQmamIgYJ6Dppo2T2EOFVkeVYWjc+PCLKaqZZ57qmLg==
+
 detect-indent@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.0.0.tgz#0abd0f549f69fc6659a254fe96786186b6f528fd"
@@ -4227,6 +4232,11 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-forge@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
@@ -4377,6 +4387,15 @@ object.values@^1.1.1:
     define-properties "^1.1.3"
     es-abstract "^1.18.0-next.2"
     has "^1.0.3"
+
+ohmyfetch@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ohmyfetch/-/ohmyfetch-0.2.0.tgz#09c03a6c107ddfe6a75c83f0a9cdaa59fb31e54b"
+  integrity sha512-tbrMD8LauY8xivHmDJItpfth/caVDHmDljeZE+4DzA2sbSp72Vzb//NJD1LtAm3pEnK5hY48i4V/zcraeiS3FQ==
+  dependencies:
+    destr "^1.1.0"
+    node-fetch "^2.6.1"
+    ufo "^0.6.10"
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -5820,6 +5839,11 @@ typescript@^4.2.3, typescript@latest:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
   integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
+
+ufo@^0.6.10:
+  version "0.6.11"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-0.6.11.tgz#69311ed4abc8ab671c83754b79ce0d396fea1075"
+  integrity sha512-Yu7TJThwlr23peOkX/+hm6LfkyBs+eDWV880468PTrjKBKjjsNWFFwIuOqDfmXngRo9TZ4+twFYueRH0OLl0Gw==
 
 uglify-js@^3.1.4:
   version "3.13.3"


### PR DESCRIPTION
`host` option was named `hostname` in `ListenOptions`. But `server.listen()` was trying to call `opts.host`, this way it did not work.

I renamed it to `host` everywhere. Shorter and fits better with `process.env.HOST`.