### PR TITLE
fix: properly invoke isWsl as a function

### DIFF
--- a/src/lib/open/index.ts
+++ b/src/lib/open/index.ts
@@ -125,7 +125,7 @@ const baseOpen = async (options) => {
   } else if (platform === 'win32' || (isWsl() && !isDocker())) {
     const mountPoint = await getWslDrivesMountPoint()
 
-    command = isWsl
+    command = isWsl()
       ? `${mountPoint}c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe`
       : `${process.env.SYSTEMROOT}\\System32\\WindowsPowerShell\\v1.0\\powershell`
 
@@ -137,7 +137,7 @@ const baseOpen = async (options) => {
       '-EncodedCommand'
     )
 
-    if (!isWsl) {
+    if (!isWsl()) {
       childProcessOptions.windowsVerbatimArguments = true
     }
 
@@ -275,7 +275,7 @@ function detectArchBinary (binary) {
 }
 
 function detectPlatformBinary ({ [platform]: platformBinary }, { wsl }) {
-  if (wsl && isWsl) {
+  if (wsl && isWsl()) {
     return detectArchBinary(wsl)
   }
 

--- a/src/lib/open/index.ts
+++ b/src/lib/open/index.ts
@@ -358,7 +358,7 @@ function _isWsl () {
 let isWSLCached
 function isWsl () {
   if (isWSLCached === undefined) {
-    isDockerCached = _isWsl()
+    isWSLCached = _isWsl()
   }
   return isWSLCached
 }


### PR DESCRIPTION
Hopefully fixes nuxt/framework#4495

I think there was a mistake when inlining `is-wsl` 3c2948f7432fb29c7cb9d020c20a7bb5cd83b253, `isWsl` in inlined version is a function, thus `isWsl == true`. Also a leftover copy paste typo.