### PR TITLE
feat: support new `networkInterfaces` for node.js >= 18

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -165,7 +165,7 @@ function getExternalIps (): string[] {
   for (const details of Object.values(networkInterfaces())) {
     if (details) {
       for (const d of details) {
-        if (d.family === 'IPv4' && !d.internal) {
+        if ((d.family === 'IPv4' || d.family === 4) && !d.internal) {
           ips.add(d.address)
         }
       }


### PR DESCRIPTION
The API for `os.networkInterfaces()` changed in the version 18 of nodejs and now the values returned for the family is either 4 (for IPv4) or 6 (for IPv6).

https://nodejs.org/dist/latest-v18.x/docs/api/os.html#osnetworkinterfaces