### PR TITLE
docs: fix wrong argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ const { url, getURL, server, close } = await listen(handle, options?)
 **Plain handle function:**
 
 ```ts
-listen('/', ((_req, res) => {
+listen(((_req, res) => {
   res.end('hi')
 })
 ```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ const { url, getURL, server, close } = await listen(handle, options?)
 **Plain handle function:**
 
 ```ts
-listen(((_req, res) => {
+listen((_req, res) => {
   res.end('hi')
 })
 ```


### PR DESCRIPTION
The first argument of `listen` function is `http.RequestListener` :)
https://github.com/unjs/listhen/blob/670eb9ebd759013cdd08470552f1379a5b6c2dad/src/index.ts#L55