### PR TITLE
fix: pass hostname to `getPort` as well

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,10 @@ export async function listen (handle: http.RequestListener, opts: Partial<Listen
     opts.clipboard = false
   }
 
-  const port = await getPort(opts.port)
+  const port = await getPort({
+    port: Number(opts.port),
+    host: opts.hostname
+  })
 
   let server: http.Server | https.Server
   let url: string


### PR DESCRIPTION
what port is available depends on the hostname we're checking, but we were always checking localhost, even when we were listening on another port

See https://github.com/nuxt/framework/issues/6322.