### PR TITLE
build: remove non existing `cjs` dist from `exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs",
       "types": "./dist/index.d.ts"
     }
   },


### PR DESCRIPTION
Currently `listhen` depends on `ip-regex` which is ESM-only. We could downgrade to a lower version of that package, but assuming we are using it, using listhen in a CJS context will throw this error:

```bash
[14:51:03]  ERROR  require() of ES Module /project/ip-regex@5.0.0/node_modules/ip-regex/index.js from /project/listhen@1.0.4/node_modules/listhen/dist/chunks/cert.cjs not supported.
Instead change the require of index.js in /project/listhen@1.0.4/node_modules/listhen/dist/chunks/cert.cjs to a dynamic import() which is available in all CommonJS modules.

  Instead change the require of index.js in node_modules/.pnpm/listhen@1.0.4/node_modules/listhen/dist/chunks/cert.cjs to a dynamic import() which is available in all CommonJS modules.
  at Object.<anonymous> (node_modules/.pnpm/listhen@1.0.4/node_modules/listhen/dist/chunks/cert.cjs:5:17)
```