### PR TITLE
test: fix order mismatch

### DIFF
--- a/test/cert.test.ts
+++ b/test/cert.test.ts
@@ -513,8 +513,8 @@ describe("Certification Tests", () => {
         extensions,
       });
       const caCert = forge.pki.certificateFromPem(ca.cert);
-      expect(() => cert.verify(caCert)).toThrowError(
-        /Encryption block is invalid.|Encrypted message is invalid./,
+      expect(() => caCert.verify(cert)).toThrowError(
+        /Could not compute certificate digest. Unknown signature OID./,
       );
 
       _private.signCertificate(
@@ -545,8 +545,8 @@ describe("Certification Tests", () => {
       });
 
       const caCert = forge.pki.certificateFromPem(ca.cert);
-      expect(() => cert.verify(caCert)).toThrowError(
-        /Encryption block is invalid.|Encrypted message is invalid./,
+      expect(() => caCert.verify(cert)).toThrowError(
+        /Could not compute certificate digest. Unknown signature OID./,
       );
 
       _private.signCertificate(


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fixes an order miss match of the variables used in 2 tests. The check should actually check if the certificate is signed with the CA, and not if the CA is signed with the certificate, since the CA is self signed.
