### PR TITLE
feat: `public` option and `--host` flag to disable network expose in development by default

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -64,10 +64,17 @@ export const main = defineCommand({
     },
     publicURL: {
       type: "string",
+      description: "Displayed public URL (used for qr code)",
       required: false,
     },
     qr: {
       type: "boolean",
+      description: "Display The QR code of public URL when available",
+      required: false,
+    },
+    public: {
+      type: "boolean",
+      description: "Listen to all network interfaces",
       required: false,
     },
   },
@@ -82,6 +89,7 @@ export const main = defineCommand({
       name: args.name,
       qr: args.qr,
       publicURL: args.publicURL,
+      public: args.public,
       https: args.https, // TODO: Support custom cert
     };
 

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -30,7 +30,7 @@ export async function listen(
   const _hostname = process.env.HOST ?? _options.hostname;
   const _public =
     _options.public ??
-    (process.argv.includes("--public") ? true : undefined) ??
+    (process.argv.includes("--host") ? true : undefined) ??
     (_hostname === "localhost" ? false : _isProd);
 
   const listhenOptions = defu<ListenOptions, ListenOptions[]>(_options, {
@@ -167,7 +167,7 @@ export async function listen(
 
     if (!listhenOptions.public) {
       lines.push(
-        colors.gray(`  > Network: use ${colors.white("--public")} to enable`),
+        colors.gray(`  > Network: use ${colors.white("--host")} to enable`),
       );
     }
 

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -30,7 +30,7 @@ export async function listen(
   const _hostname = process.env.HOST ?? _options.hostname;
   const _public =
     _options.public ??
-    process.argv.includes("--public") ??
+    (process.argv.includes("--public") ? true : undefined) ??
     (_hostname === "localhost" ? false : _isProd);
 
   const listhenOptions = defu<ListenOptions, ListenOptions[]>(_options, {

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -167,7 +167,7 @@ export async function listen(
 
     if (!listhenOptions.public) {
       lines.push(
-        colors.gray(`  > Network: use ${colors.white("--host")} to enable`),
+        colors.gray(`  > Network: use ${colors.white("--host")} to expose`),
       );
     }
 

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -25,17 +25,26 @@ export async function listen(
   handle: RequestListener,
   _options: Partial<ListenOptions> = {},
 ): Promise<Listener> {
+  const _isProd = _options.isProd ?? process.env.NODE_ENV === "production";
+  const _isTest = _options.isTest ?? process.env.NODE_ENV === "test";
+  const _hostname = process.env.HOST ?? _options.hostname;
+  const _public =
+    _options.public ??
+    process.argv.includes("--public") ??
+    (_hostname === "localhost" ? false : _isProd);
+
   const listhenOptions = defu<ListenOptions, ListenOptions[]>(_options, {
     name: "",
     https: false,
     port: process.env.PORT || 3000,
-    hostname: process.env.HOST || "",
+    hostname: _hostname ?? (_public ? "" : "localhost"),
     showURL: true,
     baseURL: "/",
     open: false,
     clipboard: false,
-    isTest: process.env.NODE_ENV === "test",
-    isProd: process.env.NODE_ENV === "production",
+    isTest: _isTest,
+    isProd: _isProd,
+    public: _public,
     autoClose: true,
   });
 
@@ -152,9 +161,13 @@ export async function listen(
       }
     } else {
       lines.push(
-        `  > Listening${name}:    ${formatURL(
-          getURL(undefined, baseURL),
-        )} ${add}`,
+        `  > Local${name}:   ${formatURL(getURL(undefined, baseURL))} ${add}`,
+      );
+    }
+
+    if (!listhenOptions.public) {
+      lines.push(
+        colors.gray(`  > Network: use ${colors.white("--public")} to enable`),
       );
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,12 @@ export interface ListenOptions {
    * @default true
    */
   qr?: boolean;
+  /**
+   * When enabled, listhen tries to listen to all network interfaces
+   *
+   * @default `false` for development and `true` for production
+   */
+  public: boolean;
 }
 
 export type GetURLOptions = Pick<Partial<ListenOptions>, "baseURL">;


### PR DESCRIPTION
### 🔗 Linked issue

resolves #88

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR introduces a new `public` option (available as `--host` cli flag implicitly with vite cli consistancy) that controls whether by default we should listen to the public network interfaces or not.

If the option is not explicitly being set, we infer it first by checking (explicit) `hostname` if being `localhost` to disable and then fallback to env check and only enable public by default for production (more compatibility) and disable for development (more security).

I suppose this is a safe nonbreaking change especially since we keep production behavior as-is, support and show `--host` flag and anyway main consumers (nuxt and nitro) are introducing this feature in the non major version. But also open to make development default and release a major version if too much trouble in the ecosystem happened which I guess won't unless there is a special complex setup. /cc @danielroe @antfu 

<img width="376" alt="image" src="https://github.com/unjs/listhen/assets/5158436/89f9f48a-0232-4b57-982c-72e10ae4481b">

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
