### PR TITLE
test(cli): https options tests with complex parsing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,7 +63,7 @@ export const main = defineCommand({
       type: "string",
       description: "Path to TLS key used with HTTPS in PEM format",
     },
-    "kettps.pfx": {
+    "https.pfx": {
       type: "string",
       description:
         "Path to PKCS#12 (.p12/.pfx) keystore containing a TLS certificate and Key",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -146,30 +146,25 @@ export const runMain = () => _runMain(main);
 export function parseHTTPSArgs(args: Record<string, any>): HTTPSOptions {
   const https: HTTPSOptions = {};
 
-  if (args["https.cert"]) {
+  if (args["https.cert"] && args["https.key"]) {
     https.cert = args["https.cert"];
-  }
-
-  if (args["https.key"]) {
     https.key = args["https.key"];
-  }
-
-  if (args["https.pfx"]) {
+  } else if (args["https.pfx"]) {
     https.pfx = args["https.pfx"];
+  } else {
+    if (args["https.validityDays"]) {
+      https.validityDays = args["https.validityDays"];
+    }
+
+    if (args["https.domains"]) {
+      https.domains = args["https.domains"]
+        .split(",")
+        .map((s: string) => s.trim());
+    }
   }
 
   if (args["https.passphrase"]) {
     https.passphrase = args["https.passphrase"];
-  }
-
-  if (args["https.validityDays"]) {
-    https.validityDays = args["https.validityDays"];
-  }
-
-  if (args["https.domains"]) {
-    https.domains = args["https.domains"]
-      .split(",")
-      .map((s: string) => s.trim());
   }
 
   return https;


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
Here are the tests for #93.

See #101 for a simpler variant of this PR.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR not only introduces tests for parsing the HTTPS CLI options, but also extends the complexity of the parsing function to prioritize a given certificate and key over a given keystore, and as a last fallback run certificate autogeneration.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
