### PR TITLE
test(cli): https options test with simple parsing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,7 +63,7 @@ export const main = defineCommand({
       type: "string",
       description: "Path to TLS key used with HTTPS in PEM format",
     },
-    "kettps.pfx": {
+    "https.pfx": {
       type: "string",
       description:
         "Path to PKCS#12 (.p12/.pfx) keystore containing a TLS certificate and Key",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,6 +2,7 @@ import { resolve } from "node:path";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { describe, afterEach, test, expect } from "vitest";
 import { listen, Listener } from "../src";
+import { parseHTTPSArgs } from "../src/cli";
 
 // eslint-disable-next-line no-console
 // console.log = fn()
@@ -48,6 +49,25 @@ describe("listhen", () => {
   });
 
   describe("https", () => {
+    test("should parse HTTPS CLI Options", () => {
+      const options = {
+        "https.cert": "cert.pem",
+        "https.key": "key.pem",
+        "https.pfx": "keystore.p12",
+        "https.passphrase": "pw",
+        "https.domains": "localhost, 127.0.0.1",
+        "https.validityDays": 10,
+      };
+      expect(parseHTTPSArgs(options)).toEqual({
+        cert: "cert.pem",
+        key: "key.pem",
+        pfx: "keystore.p12",
+        passphrase: "pw",
+        domains: ["localhost", "127.0.0.1"],
+        validityDays: 10,
+      });
+    });
+
     test("listen (https - selfsigned)", async () => {
       listener = await listen(handle, { https: true, hostname: "localhost" });
       expect(listener.url.startsWith("https://")).toBe(true);


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
Here are the tests for #93

For a more complex version of this PR see #100

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR adds a simple test for parsing all HTTPS CLI options.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
