### PR TITLE
feat: unix domain sockets and windows named pipe support

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,12 @@ Option can be a function for Node.js `upgrade` handler (`(req, head) => void`) o
 
 When using dev server CLI, you can easily use `--ws` and a named export called `websocket` to define [CrossWS Hooks](https://github.com/unjs/crossws) with HMR support!
 
+### `ipc [name]`
+
+- Default: `false [listhen]`
+
+Enables IPC (`--ipc`) through unix domain sockets on unixoid systems and named pipes on windows (unix: `/tmp/listhen.socket`; windows: `\\?\pipe\listhen`).
+
 ## License
 
 <!-- automd:contributors license=MIT author="pi0" -->

--- a/README.md
+++ b/README.md
@@ -211,9 +211,7 @@ When using dev server CLI, you can easily use `--ws` and a named export called `
 
 ### `ipc [name]`
 
-- Default: `false [listhen]`
-
-Enables IPC (`--ipc`) through unix domain sockets on unixoid systems and named pipes on windows (unix: `/tmp/listhen.socket`; windows: `\\?\pipe\listhen`).
+Enables IPC: Unix domain sockets are used on unixoid systems - instead of listening to network interfaces - and named pipes on windows (unix: `$PWD/listhen.sock`; windows: `\\?\pipe\listhen`). It's also possible to pass an absolute socket path and full pipe path.
 
 ## License
 

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -1,4 +1,5 @@
 import { networkInterfaces, platform, tmpdir } from "node:os";
+import { realpathSync } from "node:fs";
 import { relative, join, isAbsolute } from "pathe";
 import { colors } from "consola/utils";
 import { consola } from "consola";
@@ -96,7 +97,15 @@ export function getSocketPath(name: true | string) {
     }
     return `\\\\?\\pipe\\${_name}`;
   }
-  return isAbsolute(_name) ? _name : join(tmpdir(), `${_name}.socket`);
+
+  let socketPath = isAbsolute(_name)
+    ? _name
+    : join(realpathSync(tmpdir()), `${_name}`);
+
+  if (!socketPath.endsWith(".socket")) {
+    socketPath += ".socket";
+  }
+  return socketPath;
 }
 
 export function getPublicURL(

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -1,5 +1,5 @@
 import { networkInterfaces, platform, tmpdir } from "node:os";
-import { relative, join } from "pathe";
+import { relative, join, isAbsolute } from "pathe";
 import { colors } from "consola/utils";
 import { consola } from "consola";
 import { provider } from "std-env";
@@ -89,11 +89,14 @@ export function getDefaultHost(preferPublic?: boolean) {
 }
 
 export function getSocketPath(name: true | string) {
-  const _name = typeof name === "string" ? name : "listhen";
+  const _name = typeof name === "string" && name.length > 0 ? name : "listhen";
   if (platform() === "win32") {
+    if (_name.startsWith("\\\\?\\pipe\\")) {
+      return _name;
+    }
     return `\\\\?\\pipe\\${_name}`;
   }
-  return join(tmpdir(), `${_name}.socket`);
+  return isAbsolute(_name) ? _name : join(tmpdir(), `${_name}.socket`);
 }
 
 export function getPublicURL(

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -88,20 +88,12 @@ export function getDefaultHost(preferPublic?: boolean) {
   return preferPublic ? "" : "localhost";
 }
 
-export function getSocketPath(ipcSocketName: string) {
+export function getSocketPath(name: true | string) {
+  const _name = typeof name === "string" ? name : "listhen";
   if (platform() === "win32") {
-    return `\\\\?\\pipe\\${ipcSocketName || "listhen"}`;
+    return `\\\\?\\pipe\\${_name}`;
   }
-  return join(
-    tmpdir(),
-    ipcSocketName ? `${ipcSocketName}.socket` : "listhen.socket",
-  );
-}
-
-export const IPC_NOT_USED_NAME = "_____";
-
-export function isSocketUsed(options: ListenOptions): boolean {
-  return options.ipc !== IPC_NOT_USED_NAME;
+  return join(tmpdir(), `${_name}.socket`);
 }
 
 export function getPublicURL(

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -1,5 +1,5 @@
-import { networkInterfaces, platform } from "node:os";
-import { relative } from "pathe";
+import { networkInterfaces, platform, tmpdir } from "node:os";
+import { relative, join } from "pathe";
 import { colors } from "consola/utils";
 import { consola } from "consola";
 import { provider } from "std-env";
@@ -89,9 +89,13 @@ export function getDefaultHost(preferPublic?: boolean) {
 }
 
 export function getSocketPath(ipcSocketName: string) {
-  return platform() === "win32"
-    ? `\\\\?\\pipe\\${ipcSocketName || "listhen"}`
-    : `/tmp/${ipcSocketName || "listhen"}.socket`;
+  if (platform() === "win32") {
+    return `\\\\?\\pipe\\${ipcSocketName || "listhen"}`;
+  }
+  return join(
+    tmpdir(),
+    ipcSocketName ? `${ipcSocketName}.socket` : "listhen.socket",
+  );
 }
 
 export const IPC_NOT_USED_NAME = "_____";

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -1,6 +1,5 @@
-import { networkInterfaces, platform, tmpdir } from "node:os";
-import { realpathSync } from "node:fs";
-import { relative, join, isAbsolute } from "pathe";
+import { networkInterfaces, platform } from "node:os";
+import { relative } from "pathe";
 import { colors } from "consola/utils";
 import { consola } from "consola";
 import { provider } from "std-env";
@@ -98,14 +97,7 @@ export function getSocketPath(name: true | string) {
     return `\\\\?\\pipe\\${_name}`;
   }
 
-  let socketPath = isAbsolute(_name)
-    ? _name
-    : join(realpathSync(tmpdir()), `${_name}`);
-
-  if (!socketPath.endsWith(".socket")) {
-    socketPath += ".socket";
-  }
-  return socketPath;
+  return _name === "listhen" ? "listhen.sock" : _name;
 }
 
 export function getPublicURL(

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -94,6 +94,12 @@ export function getSocketPath(ipcSocketName: string) {
     : `/tmp/${ipcSocketName || "listhen"}.socket`;
 }
 
+export const IPC_NOT_USED_NAME = "_____";
+
+export function isSocketUsed(options: ListenOptions): boolean {
+  return options.ipc !== IPC_NOT_USED_NAME;
+}
+
 export function getPublicURL(
   listhenOptions: ListenOptions,
   baseURL?: string,

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -1,4 +1,4 @@
-import { networkInterfaces } from "node:os";
+import { networkInterfaces, platform } from "node:os";
 import { relative } from "pathe";
 import { colors } from "consola/utils";
 import { consola } from "consola";
@@ -86,6 +86,12 @@ export function getDefaultHost(preferPublic?: boolean) {
   // For local, use "localhost" to be developer friendly and allow loopback customization}
   // For public, use "" to listen on all NIC interfaces (IPV4 and IPV6)
   return preferPublic ? "" : "localhost";
+}
+
+export function getSocketPath(ipcSocketName: string) {
+  return platform() === "win32"
+    ? `\\\\?\\pipe\\${ipcSocketName || "listhen"}`
+    : `/tmp/${ipcSocketName || "listhen"}.socket`;
 }
 
 export function getPublicURL(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -143,7 +143,7 @@ export function getArgs() {
     },
     socket: {
       description:
-        "Listen on a Unix Domain Socket/Windows Pipe, optionally with custom name",
+        "Listen on a Unix Domain Socket/Windows Pipe, optionally with custom name or given absolute path",
       required: false,
     },
   } as const satisfies ArgsDef;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -141,6 +141,12 @@ export function getArgs() {
       description: "Open a tunnel using https://github.com/unjs/untun",
       required: false,
     },
+    ipc: {
+      type: "string",
+      description:
+        "Listen on a Unix Domain Socket/Windows Pipe, optionally with custom name",
+      required: false,
+    },
   } as const satisfies ArgsDef;
 }
 
@@ -157,6 +163,7 @@ export function parseArgs(args: ParsedListhenArgs): Partial<ListenOptions> {
     qr: args.qr,
     publicURL: args.publicURL,
     public: args.public,
+    ipc: args.ipc,
     tunnel: args.tunnel,
     https: args.https
       ? <HTTPSOptions>{

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -163,7 +163,7 @@ export function parseArgs(args: ParsedListhenArgs): Partial<ListenOptions> {
     publicURL: args.publicURL,
     public: args.public,
     tunnel: args.tunnel,
-    socket: args.socket,
+    socket: args.socket as boolean | string | undefined,
     https: args.https
       ? <HTTPSOptions>{
           cert: args["https.cert"],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -141,8 +141,7 @@ export function getArgs() {
       description: "Open a tunnel using https://github.com/unjs/untun",
       required: false,
     },
-    ipc: {
-      type: "string",
+    socket: {
       description:
         "Listen on a Unix Domain Socket/Windows Pipe, optionally with custom name",
       required: false,
@@ -163,8 +162,8 @@ export function parseArgs(args: ParsedListhenArgs): Partial<ListenOptions> {
     qr: args.qr,
     publicURL: args.publicURL,
     public: args.public,
-    ipc: args.ipc,
     tunnel: args.tunnel,
+    socket: args.socket,
     https: args.https
       ? <HTTPSOptions>{
           cert: args["https.cert"],

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -117,8 +117,6 @@ export async function listen(
     ? { path: getSocketPath(listhenOptions.socket) }
     : { port, host: listhenOptions.hostname };
 
-  let addr: { proto: "http" | "https"; addr: string; port: number } | null;
-
   let https: Listener["https"] = false;
   const httpsOptions = listhenOptions.https as HTTPSOptions;
 
@@ -160,7 +158,9 @@ export async function listen(
 
   // --- GetURL Utility ---
   const getURL = (host = listhenOptions.hostname, baseURL?: string) =>
-    generateURL(host, listhenOptions, baseURL);
+    serverOptions.path
+      ? `unix+http${listhenOptions.https ? "s" : ""}://${serverOptions.path}`
+      : generateURL(host, listhenOptions, baseURL);
 
   // --- Start Tunnel ---
   let tunnel: Tunnel | undefined;
@@ -203,8 +203,8 @@ export async function listen(
       }
     };
 
-    if (listhenOptions.socket) {
-      _addURL("local", ipcSocket);
+    if (serverOptions.path) {
+      _addURL("local", serverOptions.path);
       return urls;
     }
 

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -12,6 +12,7 @@ import { ColorName, getColor, colors } from "consola/utils";
 import { renderUnicodeCompact as renderQRCode } from "uqr";
 import type { Tunnel } from "untun";
 import type { AdapterOptions as CrossWSOptions } from "crossws";
+import { isAbsolute, sep } from "pathe";
 import { open } from "./lib/open";
 import type {
   ListenOptions,
@@ -204,7 +205,13 @@ export async function listen(
     };
 
     if (serverOptions.path) {
-      _addURL("local", serverOptions.path);
+      let _path = serverOptions.path
+      const currentDirPath = `.${sep}`
+
+      if (!(isAbsolute(_path) || _path.startsWith(currentDirPath))) {
+        _path = currentDirPath + _path
+      }
+      _addURL("local", _path);
       return urls;
     }
 

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -205,11 +205,11 @@ export async function listen(
     };
 
     if (serverOptions.path) {
-      let _path = serverOptions.path
-      const currentDirPath = `.${sep}`
+      let _path = serverOptions.path;
+      const currentDirPath = `.${sep}`;
 
       if (!(isAbsolute(_path) || _path.startsWith(currentDirPath))) {
-        _path = currentDirPath + _path
+        _path = currentDirPath + _path;
       }
       _addURL("local", _path);
       return urls;

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,11 @@ export interface ListenOptions {
     | boolean
     | CrossWSOptions
     | ((req: IncomingMessage, head: Buffer) => void);
+   * Listhen on a unix domain socket/windows pipe, optionally with custom name
+   *
+   * @default listhen
+   */
+  ipc: string;
 }
 
 export type GetURLOptions = Pick<

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,8 +67,8 @@ export interface ListenOptions {
     | boolean
     | CrossWSOptions
     | ((req: IncomingMessage, head: Buffer) => void);
+  /**
    * Listhen on a unix domain socket/windows pipe, optionally with custom name
-   *
    */
   socket: boolean | string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,9 +69,8 @@ export interface ListenOptions {
     | ((req: IncomingMessage, head: Buffer) => void);
    * Listhen on a unix domain socket/windows pipe, optionally with custom name
    *
-   * @default listhen
    */
-  ipc: string;
+  socket: boolean | string;
 }
 
 export type GetURLOptions = Pick<

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -57,7 +57,7 @@ function ipcRequest(ipcSocket: string, path: string, https = false) {
         });
         res.on("end", () => {
           try {
-            resolve(JSON.parse(data.join("")));
+            resolve(JSON.parse(data));
           } catch {
             resolve(data.join(""));
           }
@@ -88,9 +88,11 @@ describe("listhen", () => {
     await expect(ipcRequest(ipcSocket, "/unix", https)).resolves.toEqual({
       hello: "unix!",
     });
-    await expect(ipcRequest(ipcSocket, "/test", https)).resolves.toContain({
-      statusCode: 404,
-    });
+    const response = await ipcRequest(ipcSocket, "/test", https);
+    expect(response.statusCode).toEqual(404);
+    expect(response.statusMessage).toEqual(
+      "Cannot find any path matching /test.",
+    );
   }
 
   async function handleAssertions(ipcSocket: string, https: boolean) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -135,7 +135,7 @@ describe("listhen", () => {
     const ipcSocket = getSocketPath(ipcSocketName);
 
     listener = await listen(handle, {
-      ipc: ipcSocketName,
+      socket: ipcSocketName,
     });
 
     await handleAssertions(ipcSocket, false);
@@ -146,7 +146,7 @@ describe("listhen", () => {
     const ipcSocket = getSocketPath(ipcSocketName);
 
     listener = await listen(toNodeListener(getApp()), {
-      ipc: ipcSocketName,
+      socket: ipcSocketName,
     });
 
     expect(listener.url).toBe(ipcSocket);
@@ -178,7 +178,7 @@ describe("listhen", () => {
       const ipcSocket = getSocketPath(ipcSocketName);
 
       listener = await listen(handle, {
-        ipc: ipcSocketName,
+        socket: ipcSocketName,
         https: true,
       });
 
@@ -192,7 +192,7 @@ describe("listhen", () => {
       const ipcSocket = getSocketPath(ipcSocketName);
 
       listener = await listen(toNodeListener(getApp()), {
-        ipc: ipcSocketName,
+        socket: ipcSocketName,
         https: true,
       });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,8 +1,9 @@
-import { resolve } from "node:path";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { request } from "node:http";
 import { request as httpsRequest } from "node:https";
-import { platform } from "node:os";
+import { platform, tmpdir } from "node:os";
+import { realpathSync } from "node:fs";
+import { resolve, join } from "pathe";
 import { describe, afterEach, test, expect } from "vitest";
 import { toNodeListener, createApp, eventHandler, createRouter } from "h3";
 import { listen, Listener } from "../src";
@@ -314,8 +315,9 @@ describe("listhen", () => {
           expect(getSocketPath(undefined!)).toEqual("\\\\?\\pipe\\listhen");
           expect(getSocketPath("")).toEqual("\\\\?\\pipe\\listhen");
         } else {
-          expect(getSocketPath(undefined!)).toEqual("/tmp/listhen.socket");
-          expect(getSocketPath("")).toEqual("/tmp/listhen.socket");
+          const socketPath = join(realpathSync(tmpdir()), "listhen.socket");
+          expect(getSocketPath(undefined!)).toEqual(socketPath);
+          expect(getSocketPath("")).toEqual(socketPath);
         }
       });
 
@@ -325,9 +327,11 @@ describe("listhen", () => {
             "\\\\?\\pipe\\listhen-https",
           );
         } else {
-          expect(getSocketPath("listhen-https")).toEqual(
-            "/tmp/listhen-https.socket",
+          const socketPath = join(
+            realpathSync(tmpdir()),
+            "listhen-https.socket",
           );
+          expect(getSocketPath("listhen-https")).toEqual(socketPath);
         }
       });
 
@@ -347,12 +351,13 @@ describe("listhen", () => {
             "\\\\?\\pipe\\tmp\\listhen",
           );
         } else {
-          expect(getSocketPath("tmp/listhen.socket")).toEqual(
-            "/tmp/tmp/listhen.socket.socket",
+          const socketPath = join(
+            realpathSync(tmpdir()),
+            "tmp",
+            "listhen.socket",
           );
-          expect(getSocketPath("tmp/listhen")).toEqual(
-            "/tmp/tmp/listhen.socket",
-          );
+          expect(getSocketPath("tmp/listhen.socket")).toEqual(socketPath);
+          expect(getSocketPath("tmp/listhen")).toEqual(socketPath);
         }
       });
     });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -308,26 +308,53 @@ describe("listhen", () => {
   });
 
   describe("_utils", () => {
-    test("getSocketPath: empty ipcSocketName resolves to a 'listhen' named pipe/socket", () => {
-      if (platform() === "win32") {
-        expect(getSocketPath(undefined!)).toEqual("\\\\?\\pipe\\listhen");
-        expect(getSocketPath("")).toEqual("\\\\?\\pipe\\listhen");
-      } else {
-        expect(getSocketPath(undefined!)).toEqual("/tmp/listhen.socket");
-        expect(getSocketPath("")).toEqual("/tmp/listhen.socket");
-      }
-    });
+    describe("socket path", () => {
+      test("empty ipcSocketName resolves to a 'listhen' named pipe/socket", () => {
+        if (platform() === "win32") {
+          expect(getSocketPath(undefined!)).toEqual("\\\\?\\pipe\\listhen");
+          expect(getSocketPath("")).toEqual("\\\\?\\pipe\\listhen");
+        } else {
+          expect(getSocketPath(undefined!)).toEqual("/tmp/listhen.socket");
+          expect(getSocketPath("")).toEqual("/tmp/listhen.socket");
+        }
+      });
 
-    test("getSocketPath: some string as ipcSocketName resolves to a pipe/socket named as this string", () => {
-      if (platform() === "win32") {
-        expect(getSocketPath("listhen-https")).toEqual(
-          "\\\\?\\pipe\\listhen-https",
-        );
-      } else {
-        expect(getSocketPath("listhen-https")).toEqual(
-          "/tmp/listhen-https.socket",
-        );
-      }
+      test("some string as ipcSocketName resolves to a pipe/socket named as this string", () => {
+        if (platform() === "win32") {
+          expect(getSocketPath("listhen-https")).toEqual(
+            "\\\\?\\pipe\\listhen-https",
+          );
+        } else {
+          expect(getSocketPath("listhen-https")).toEqual(
+            "/tmp/listhen-https.socket",
+          );
+        }
+      });
+
+      test("absolute path (or full pipe path) resolves to the exact same path", () => {
+        if (platform() === "win32") {
+          const pipe = "\\\\?\\pipe\\listhen";
+          expect(getSocketPath(pipe)).toEqual(pipe);
+        } else {
+          const socket = "/tmp/listhen.socket";
+          expect(getSocketPath(socket)).toEqual(socket);
+        }
+      });
+
+      test("relative path resolves to a socket named as this relative path", () => {
+        if (platform() === "win32") {
+          expect(getSocketPath("tmp\\listhen")).toEqual(
+            "\\\\?\\pipe\\tmp\\listhen",
+          );
+        } else {
+          expect(getSocketPath("tmp/listhen.socket")).toEqual(
+            "/tmp/tmp/listhen.socket.socket",
+          );
+          expect(getSocketPath("tmp/listhen")).toEqual(
+            "/tmp/tmp/listhen.socket",
+          );
+        }
+      });
     });
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -77,7 +77,7 @@ describe("listhen", () => {
     }
   });
   async function h3AppAssertions(ipcSocket: string, https: boolean) {
-    expect(listener!.url).toBe(ipcSocket);
+    expect(listener!.url).toBe(`unix+http${https ? "s" : ""}://${ipcSocket}`);
 
     await expect(ipcRequest(ipcSocket, "/", https)).resolves.toEqual({
       hello: "world!",
@@ -94,7 +94,7 @@ describe("listhen", () => {
   }
 
   async function handleAssertions(ipcSocket: string, https: boolean) {
-    expect(listener!.url).toBe(ipcSocket);
+    expect(listener!.url).toBe(`unix+http${https ? "s" : ""}://${ipcSocket}`);
 
     await expect(ipcRequest(ipcSocket, "/", https)).resolves.toEqual("/");
     await expect(ipcRequest(ipcSocket, "/path", https)).resolves.toEqual(
@@ -149,7 +149,7 @@ describe("listhen", () => {
       socket: ipcSocketName,
     });
 
-    expect(listener.url).toBe(ipcSocket);
+    expect(listener.url).toBe(`unix+http://${ipcSocket}`);
 
     await h3AppAssertions(ipcSocket, false);
   });
@@ -182,7 +182,7 @@ describe("listhen", () => {
         https: true,
       });
 
-      expect(listener.url).toBe(ipcSocket);
+      expect(listener.url).toBe(`unix+https://${ipcSocket}`);
 
       await handleAssertions(ipcSocket, true);
     });


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
Closes #1

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Here is yet another hopefully promising PR :grin:

These PR adds support for listening on **unix domain sockets** or on **windows named pipes**. It adds the assignable CLI options, copies the full socket/pipe path to clipboard if wanted, prints the socket path and ignores all HTTPS options and also the `--open` option.

While developing this PR, I recognized, that the `close()` function is neither called when the terminal is closed, nor when the process gets interrupted with `Ctrl + C`, so I added 3 signal traps to trigger the close call. With these traps the socket will get automatically cleaned up; without these traps - and without proper termination - the socket needs to be deleted manually before starting `listhen` again.

2 tests are included. Unlike the **h3 app** test, the **handle** test is returning the same result for non existing paths. Is this expected behavior?

I've successfully executed the tests on **Manjaro** and on **Windows 10**.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
