### PR TITLE
fix: better options handling for public host

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,10 +94,10 @@ importers:
   playground:
     dependencies:
       h3:
-        specifier: ^1.8.0-rc.3
+        specifier: ^1.8.0
         version: 1.8.0
       listhen:
-        specifier: ^1.2.2
+        specifier: ^1.4.1
         version: link:..
 
 packages:
@@ -919,6 +919,7 @@ packages:
     dependencies:
       is-glob: 4.0.3
       micromatch: 4.0.5
+      napi-wasm: 1.1.0
     dev: false
     bundledDependencies:
       - napi-wasm
@@ -3338,6 +3339,10 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
     dev: true
+
+  /napi-wasm@1.1.0:
+    resolution: {integrity: sha512-lHwIAJbmLSjF9VDRm9GoVOy9AGp3aIvkjv+Kvz9h16QR3uSVYH78PNQUnT2U4X53mhlnV2M7wrhibQ3GHicDmg==}
+    dev: false
 
   /natural-compare-lite@1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -41,18 +41,12 @@ export function formatURL(url: string) {
 
 const localhostRegex = /^127(\.\d{1,3}){3}$|^localhost$|^::1$/;
 export function isLocalhost(hostname: string | undefined) {
-  if (hostname === undefined) {
-    return false;
-  }
-  return localhostRegex.test(hostname);
+  return hostname === undefined ? false : localhostRegex.test(hostname);
 }
 
 const anyhostRegex = /^$|^0\.0\.0\.0$|^::$/;
 export function isAnyhost(hostname: string | undefined) {
-  if (hostname === undefined) {
-    return false;
-  }
-  return anyhostRegex.test(hostname);
+  return hostname === undefined ? false : anyhostRegex.test(hostname);
 }
 
 export function getPublicURL(

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -41,7 +41,7 @@ export function formatURL(url: string) {
 
 const localhostRegex = /^127(\.\d{1,3}){3}$|^localhost$|^::1$/;
 export function isLocalhost(hostname = "") {
-  return localhostRegex.test(hostname)
+  return localhostRegex.test(hostname);
 }
 
 export function isAnyhost(hostname = "") {

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -40,11 +40,17 @@ export function formatURL(url: string) {
 }
 
 const localhostRegex = /^127(\.\d{1,3}){3}$|^localhost$|^::1$/;
-export function isLocalhost(hostname = "") {
+export function isLocalhost(hostname: string | undefined) {
+  if (hostname === undefined) {
+    return false;
+  }
   return localhostRegex.test(hostname);
 }
 
-export function isAnyhost(hostname = "") {
+export function isAnyhost(hostname: string | undefined) {
+  if (hostname === undefined) {
+    return false;
+  }
   return hostname === "" || hostname === "0.0.0.0" || hostname === "::";
 }
 

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -39,6 +39,15 @@ export function formatURL(url: string) {
   );
 }
 
+const localhostRegex = /^127(\.\d{1,3}){3}$|^localhost$|^::1$/;
+export function isLocalhost(hostname = "") {
+  return localhostRegex.test(hostname)
+}
+
+export function isAnyhost(hostname = "") {
+  return hostname === "" || hostname === "0.0.0.0" || hostname === "::";
+}
+
 export function getPublicURL(
   urls: ListenURL[],
   listhenOptions: ListenOptions,

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -47,11 +47,12 @@ export function isLocalhost(hostname: string | undefined) {
   return localhostRegex.test(hostname);
 }
 
+const anyhostRegex = /^$|^0\.0\.0\.0$|^::$/;
 export function isAnyhost(hostname: string | undefined) {
   if (hostname === undefined) {
     return false;
   }
-  return hostname === "" || hostname === "0.0.0.0" || hostname === "::";
+  return anyhostRegex.test(hostname);
 }
 
 export function getPublicURL(


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR improves the options handling for public hosts.

If `public` is not explicitly provided, we infer it in this order:
   - `hostname` is explicitly localhost ? `false`
   - `hostname` is explicitly anyhost range ? `true`
   - `--host` flag provided (any value)? `true` (this is for CLI auto compatibility)
   - production env ? `true`
   - `false`

Listhen also shows smart warnings if options are used wrongly together:

- Public enabled and hostname is localhost:
  - Show a warning that it is not going to listhen to anything public
  - Fix internal `public` option to `false`
- Public is disabled and hostname is anyhost:
  - Show a warning that public config is going to be disabled
  - Force listen to `localhost` to avoid security implications

**Note:** Tunnel is a separate concept from public. One might choose to listen on either localhost or local network exposed server and expose a (private by default) tunnel.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
