### PR TITLE
fix: use ipv4 for windows and wsl default hosts

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -2,6 +2,7 @@ import { networkInterfaces } from "node:os";
 import { relative } from "pathe";
 import { colors } from "consola/utils";
 import { ListenOptions } from "./types";
+import { isWsl } from "./lib/wsl";
 
 export function getNetworkInterfaces(includeIPV6?: boolean): string[] {
   const addrs = new Set<string>();
@@ -68,6 +69,16 @@ export function generateURL(
   return (
     proto + hostname + ":" + port + (baseURL || listhenOptions.baseURL || "")
   );
+}
+
+export function getDefaultHost(preferPublic?: boolean) {
+  // Prefer IPV4 stack for Windows and WSL to avoid performance issues
+  if (process.platform === "win32" || isWsl()) {
+    return preferPublic ? "0.0.0.0" : "127.0.0.1";
+  }
+  // For local, use "localhost" to be developer friendly and allow loopback customization}
+  // For public, use "" to listen on all NIC interfaces (IPV4 and IPV6)
+  return preferPublic ? "" : "localhost";
 }
 
 export function getPublicURL(

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -27,6 +27,7 @@ import {
   isAnyhost,
   getPublicURL,
   generateURL,
+  getDefaultHost,
 } from "./_utils";
 import { resolveCertificate } from "./_cert";
 
@@ -49,7 +50,7 @@ export async function listen(
     name: "",
     https: false,
     port: process.env.PORT || 3000,
-    hostname: _hostname ?? (_public ? "" : "localhost"),
+    hostname: _hostname ?? getDefaultHost(_public),
     showURL: true,
     baseURL: "/",
     open: false,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Reports in https://github.com/nuxt/cli/issues/109

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Windows IP stack can confuse for resolving `localhost` between IPv4 and IPv6 stacks.

For more safety, i also changed to prefer IPv4 anyhost (`0.0.0.0`) by default for windows. (It can be always overridden by users using `hostname` and `HOST`)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
