### PR TITLE
fix: open browser on wsl

### DIFF
--- a/src/lib/wsl.ts
+++ b/src/lib/wsl.ts
@@ -35,41 +35,40 @@ function _isWsl() {
 // Get the mount point for fixed drives in WSL.
 const defaultMountPoint = "/mnt/";
 let _wslMountpoint: string;
+
+// Default value for "root" param
+// according to https://docs.microsoft.com/en-us/windows/wsl/wsl-config
 export function getWslDrivesMountPoint() {
-  // Default value for "root" param
-  // according to https://docs.microsoft.com/en-us/windows/wsl/wsl-config
-  return function getWslDrivesMountPoint() {
-    if (_wslMountpoint) {
-      // Return memoized mount point value
-      return _wslMountpoint;
-    }
-
-    const configFilePath = "/etc/wsl.conf";
-
-    let isConfigFileExists = false;
-    try {
-      accessSync(configFilePath, fsConstants.F_OK);
-      isConfigFileExists = true;
-    } catch {}
-
-    if (!isConfigFileExists) {
-      return defaultMountPoint;
-    }
-
-    const configContent = readFileSync(configFilePath, { encoding: "utf8" });
-    const configMountPoint = /(?<!#.*)root\s*=\s*(?<mountPoint>.*)/g.exec(
-      configContent,
-    );
-
-    if (!configMountPoint || !configMountPoint.groups) {
-      return defaultMountPoint;
-    }
-
-    _wslMountpoint = configMountPoint.groups.mountPoint.trim();
-    _wslMountpoint = _wslMountpoint.endsWith("/")
-      ? _wslMountpoint
-      : `${_wslMountpoint}/`;
-
+  if (_wslMountpoint) {
+    // Return memoized mount point value
     return _wslMountpoint;
-  };
+  }
+
+  const configFilePath = "/etc/wsl.conf";
+
+  let isConfigFileExists = false;
+  try {
+    accessSync(configFilePath, fsConstants.F_OK);
+    isConfigFileExists = true;
+  } catch {}
+
+  if (!isConfigFileExists) {
+    return defaultMountPoint;
+  }
+
+  const configContent = readFileSync(configFilePath, { encoding: "utf8" });
+  const configMountPoint = /(?<!#.*)root\s*=\s*(?<mountPoint>.*)/g.exec(
+    configContent,
+  );
+
+  if (!configMountPoint || !configMountPoint.groups) {
+    return defaultMountPoint;
+  }
+
+  _wslMountpoint = configMountPoint.groups.mountPoint.trim();
+  _wslMountpoint = _wslMountpoint.endsWith("/")
+    ? _wslMountpoint
+    : `${_wslMountpoint}/`;
+
+  return _wslMountpoint;
 }


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #123

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`getWslDrivesMountPoint` was returning a function, which then send to `childProcess.span`, which results in an error:

![image](https://github.com/unjs/listhen/assets/3911343/57341fff-ed63-496f-ba8c-2213c639f269)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
