### PR TITLE
perf: imprve default host for windows, docker and wsl

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -4,6 +4,7 @@ import { colors } from "consola/utils";
 import { consola } from "consola";
 import { ListenOptions } from "./types";
 import { isWsl } from "./lib/wsl";
+import { isDocker } from "./lib/docker";
 
 export function getNetworkInterfaces(includeIPV6?: boolean): string[] {
   const addrs = new Set<string>();
@@ -73,9 +74,9 @@ export function generateURL(
 }
 
 export function getDefaultHost(preferPublic?: boolean) {
-  // Prefer IPV4 stack for Windows and WSL to avoid performance issues
-  if (process.platform === "win32" || isWsl()) {
-    return preferPublic ? "0.0.0.0" : "127.0.0.1";
+  // Prefer default host for docker and wsl
+  if (isDocker() || isWsl()) {
+    return "";
   }
   // For local, use "localhost" to be developer friendly and allow loopback customization}
   // For public, use "" to listen on all NIC interfaces (IPV4 and IPV6)
@@ -135,7 +136,7 @@ const HOSTNAME_RE = /^(?!-)[\d.:A-Za-z-]{1,63}(?<!-)$/;
 
 export function validateHostname(hostname: string, _public: boolean) {
   if (hostname && !HOSTNAME_RE.test(hostname)) {
-    const fallbackHost = _public ? "0.0.0.0" : "127.0.0.1";
+    const fallbackHost = _public ? "" : "localhost";
     consola.warn(
       `[listhen] Invalid hostname \`${hostname}\`. Using \`${fallbackHost}\` as fallback.`,
     );

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -72,15 +72,13 @@ export async function listen(
   const _localhost = isLocalhost(listhenOptions.hostname);
   const _anyhost = isAnyhost(listhenOptions.hostname);
   if (listhenOptions.public && _localhost) {
-    if (!isWsl() && !isDocker()) {
-      consola.warn(
-        `[listhen] Trying to listhen on private host ${JSON.stringify(
-          listhenOptions.hostname,
-        )} with public option disabled.`,
-      );
-      listhenOptions.public = false;
-    }
-  } else if (!listhenOptions.public && _anyhost) {
+    consola.warn(
+      `[listhen] Trying to listhen on private host ${JSON.stringify(
+        listhenOptions.hostname,
+      )} with public option disabled.`,
+    );
+    listhenOptions.public = false;
+  } else if (!listhenOptions.public && _anyhost && !(isWsl() || isDocker())) {
     consola.warn(
       `[listhen] Trying to listhen on public host ${JSON.stringify(
         listhenOptions.hostname,

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -31,6 +31,8 @@ import {
   validateHostname,
 } from "./_utils";
 import { resolveCertificate } from "./_cert";
+import { isWsl } from "./lib/wsl";
+import { isDocker } from "./lib/docker";
 
 export async function listen(
   handle: RequestListener,
@@ -70,12 +72,14 @@ export async function listen(
   const _localhost = isLocalhost(listhenOptions.hostname);
   const _anyhost = isAnyhost(listhenOptions.hostname);
   if (listhenOptions.public && _localhost) {
-    consola.warn(
-      `[listhen] Trying to listhen on private host ${JSON.stringify(
-        listhenOptions.hostname,
-      )} with public option disabled.`,
-    );
-    listhenOptions.public = false;
+    if (!isWsl() && !isDocker()) {
+      consola.warn(
+        `[listhen] Trying to listhen on private host ${JSON.stringify(
+          listhenOptions.hostname,
+        )} with public option disabled.`,
+      );
+      listhenOptions.public = false;
+    }
   } else if (!listhenOptions.public && _anyhost) {
     consola.warn(
       `[listhen] Trying to listhen on public host ${JSON.stringify(


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Since we had defaulted the host from anyhost to local, there had been several performance issues often either related to the ipv4/ipv6 dual stack or isolated envs (docker and WSL)

With #119 listen changed to prefer ipv4 stack `127.0.0.1` for Windows and WSL, however, it introduced performance regressions for Windows users when users type in `localhost` in the browser (it takes time from OS to first try `::1` as ipv6 localhost and falling back to `127.0.0.1`).

This PR tries to make behavior more reasonable:
- For Windows, same as MacOS and Linux listen on. My tests showed `localhost` perfectly works fast in different scenarios
- For wsl and docker, always use `""` (anyhost). These are by default isolated environments and need to be exposed by their runtime. Listening on all available interfaces makes it faster. 
- For invalid hostnames, prefer dual stack by default as fallback


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
