### PR TITLE
fix(dev): fix absolute paths import on windows

### DIFF
--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -3,7 +3,7 @@ import { readFile, stat } from "node:fs/promises";
 import { consola } from "consola";
 import { dirname, join, resolve } from "pathe";
 import type { ConsolaInstance } from "consola";
-import { resolvePath } from "mlly";
+import { resolve as _resolve } from "mlly";
 import { createResolver } from "./_resolver";
 
 export interface DevServerOptions {
@@ -18,7 +18,7 @@ export async function createDevServer(
 ) {
   const logger = options.logger || consola.withTag("listhen");
 
-  const h3Entry = await resolvePath("h3", {
+  const h3Entry = await _resolve("h3", {
     url: [options.cwd!, process.cwd(), import.meta.url].filter(Boolean),
   });
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

When running [ipx](https://github.com/unjs/ipx)'s `pnpm run dev` following environments, failed to import `h3Entry` in `createDevServer`.

- Operating System: Windows_NT
- Node Version:     v20.10.0
- Package Manager:  pnpm@8.10.2

```
pnpm run dev 

> ipx@2.0.2 dev C:\Users\......\github.com\unjs\ipx
> listhen -w playground

ERROR  Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
