### PR TITLE
feat: experimental websocket support

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-workspace-root-check=true

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Elegant HTTP listener!
 
 ## Features
 
-✅ Dev server with HMR, static, and typescript support with <a href="https://github.com/unjs/jiti">unjs/jiti</a><br>
+✅ Dev server with HMR, static, WebSockets and typescript support with <a href="https://github.com/unjs/jiti">unjs/jiti</a><br>
 
 ✅ Works with Node.js, express, and <a href="https://github.com/unjs/h3">unjs/h3</a> out of the box <br>
 
@@ -23,6 +23,8 @@ Elegant HTTP listener!
 ✅ Assign a port or fallback to a nicer alternative with <a href="https://github.com/unjs/get-port-please">unjs/get-port-please</a>
 
 ✅ Gracefully shutdown Server with <a href="https://github.com/thedillonb/http-shutdown">http-shutdown</a><br>
+
+✅ Zero Config WebSockets with <a href="https://github.com/unjs/crossws">unjs/crossws</a>
 
 ✅ Copy the URL to the clipboard<br>
 
@@ -57,7 +59,10 @@ import { createApp, eventHandler } from "h3";
 
 export const app = createApp();
 
-app.use("/", eventHandler(() => "Hello world!"));
+app.use(
+  "/",
+  eventHandler(() => "Hello world!"),
+);
 ```
 
 or use npx to invoke `listhen` command:
@@ -192,6 +197,16 @@ Print QR Code for public address.
 - Default: `false` for development or when `hostname` is `localhost` and `true` for production
 
 When enabled, listhen tries to listen to all network interfaces. You can also enable this option using `--host` CLI flag.
+
+### `ws`
+
+- Default: `false`
+
+Enable experimental WebSocket support.
+
+Option can be a function for Node.js `upgrade` handler (`(req, head) => void`) or an Object to use [CrossWS Hooks](https://github.com/unjs/crossws).
+
+When using dev server CLI, you can easily use `--ws` and a named export called `webSocket` to define [CrossWS Hooks](https://github.com/unjs/crossws) with HMR support!
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint": "eslint --ext .ts . && prettier -c src test",
     "lint:fix": "eslint --fix --ext .ts . && prettier -w src test",
     "listhen": "node ./scripts/listhen.mjs",
-    "play": "node ./scripts/listhen.mjs -w ./playground",
+    "play": "node ./scripts/listhen.mjs -w ./playground --ws",
     "release": "pnpm test && pnpm build && changelogen --release && pnpm publish && git push --follow-tags",
     "test": "pnpm lint && vitest run --coverage"
   },

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "citty": "^0.1.5",
     "clipboardy": "^4.0.0",
     "consola": "^3.2.3",
+    "crossws": "^0.1.0",
     "defu": "^6.1.4",
     "get-port-please": "^3.1.2",
     "h3": "^1.10.1",

--- a/playground/index.ts
+++ b/playground/index.ts
@@ -50,11 +50,11 @@ function getWebSocketTestPage() {
 
 export const webSocket = defineWebSocketHooks({
   open(peer) {
-    console.log("[ws]] open", peer);
+    console.log("[ws] open", peer);
     peer.send("Hello!");
   },
   message(peer, message) {
-    console.log("[ws]] message", peer);
+    console.log("[ws] message", peer);
     if (message.text() === "ping") {
       peer.send("pong");
     }

--- a/playground/index.ts
+++ b/playground/index.ts
@@ -1,8 +1,62 @@
 import { createApp, eventHandler } from "h3";
+import { defineWebSocketHooks } from "crossws";
 
 export const app = createApp();
+
+app.use(
+  "/ws",
+  eventHandler(() => {
+    return getWebSocketTestPage();
+  }),
+);
 
 app.use(
   "/",
   eventHandler(() => ({ hello: "world!" })),
 );
+
+function getWebSocketTestPage() {
+  return `
+  <!doctype html>
+  <head>
+    <title>WebSocket Test Page</title>
+  </head>
+  <body>
+    <div id="logs"></div>
+    <script type="module">
+      const url = \`ws://\${location.host}/_ws\`;
+      const logsEl = document.querySelector("#logs");
+      const log = (...args) => {
+        console.log("[ws]", ...args);
+        logsEl.innerHTML += \`<p>[\${new Date().toJSON()}] \${args.join(" ")}</p>\`;
+      };
+
+      log(\`Connecting to "\${url}""...\`);
+      const ws = new WebSocket(url);
+
+      ws.addEventListener("message", (event) => {
+        log("Message from server:", event.data);
+      });
+
+      log("Waiting for connection...");
+      await new Promise((resolve) => ws.addEventListener("open", resolve));
+
+      log("Sending ping...");
+      ws.send("ping");
+    </script>
+  </body>
+    `;
+}
+
+export const webSocket = defineWebSocketHooks({
+  open(peer) {
+    console.log("[ws]] open", peer);
+    peer.send("Hello!");
+  },
+  message(peer, message) {
+    console.log("[ws]] message", peer);
+    if (message.text() === "ping") {
+      peer.send("pong");
+    }
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       consola:
         specifier: ^3.2.3
         version: 3.2.3
+      crossws:
+        specifier: ^0.1.0
+        version: 0.1.0
       defu:
         specifier: ^6.1.4
         version: 6.1.4
@@ -1679,6 +1682,10 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  /crossws@0.1.0:
+    resolution: {integrity: sha512-k/CMEn83hK9xflL4RD4puf+qOgTjTsA8svK+u/fkbKCrVzthkWAhiXpXc49Ju5V+aa3TqM3EW+0ROixh1MclzA==}
+    dev: false
 
   /css-declaration-sorter@7.1.1(postcss@8.4.33):
     resolution: {integrity: sha512-dZ3bVTEEc1vxr3Bek9vGwfB5Z6ESPULhcRvO472mfjVnj8jRcTnKO8/JTczlvxM10Myb+wBM++1MtdO76eWcaQ==}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,6 +57,7 @@ export const main = defineCommand({
       await listen(devServer.nodeListener, {
         ...opts,
         _entry: devServer._entry,
+        ws: opts.ws ? devServer._ws : undefined,
       });
       await devServer.reload(true);
     }
@@ -84,6 +85,10 @@ export function getArgs() {
     open: {
       type: "boolean",
       description: "Open the URL in the browser",
+    },
+    ws: {
+      type: "boolean",
+      description: "Enable Experimental WebSocket support",
     },
     https: {
       type: "boolean",

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -129,6 +129,23 @@ export async function listen(
     listhenOptions.port = _addr.port;
   }
 
+  // --- WebSocket ---
+  if (listhenOptions.ws) {
+    if (typeof listhenOptions.ws === "function") {
+      server.on("upgrade", listhenOptions.ws);
+    } else {
+      consola.warn(
+        "[listhen] Using experimental websocket API. Learn more: `https://crossws.unjs.io`",
+      );
+      const nodeWSAdapter = await import("crossws/adapters/node").then(
+        (r) => r.default || r,
+      );
+      // @ts-expect-error TODO
+      const { handleUpgrade } = nodeWSAdapter(listhenOptions.ws);
+      server.on("upgrade", handleUpgrade);
+    }
+  }
+
   // --- GetURL Utility ---
   const getURL = (host = listhenOptions.hostname, baseURL?: string) =>
     generateURL(host, listhenOptions, baseURL);

--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -11,7 +11,7 @@ export interface DevServerOptions {
   cwd?: string;
   staticDirs?: string[];
   logger?: ConsolaInstance;
-  ws?: boolean;
+  ws?: boolean | Partial<WebSocketHooks>;
 }
 
 export async function createDevServer(
@@ -62,7 +62,10 @@ export async function createDevServer(
   if (options.ws) {
     const createDynamicHook =
       (name: string) =>
-      (...args: any[]) => {
+      async (...args: any[]) => {
+        if (typeof options.ws === "object") {
+          await (options.ws as any)[name]?.(...args);
+        }
         return (webSocketHooks as any)[name]?.(...args);
       };
     _ws = new Proxy(

--- a/src/server/watcher.ts
+++ b/src/server/watcher.ts
@@ -22,7 +22,7 @@ export async function listenAndWatch(
 
   // Create dev server
   const devServer = await createDevServer(entry, {
-    cwd: options.cwd,
+    ...options,
     logger,
   });
 
@@ -30,6 +30,7 @@ export async function listenAndWatch(
   const listenter = await listen(devServer.nodeListener, {
     ...options,
     _entry: devServer._entry,
+    ws: options.ws ? devServer._ws : undefined,
   });
 
   // Load dev server handler first time

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,8 @@
-import type { Server } from "node:http";
+import type { IncomingMessage, Server } from "node:http";
 import type { Server as HTTPServer } from "node:https";
 import { AddressInfo } from "node:net";
 import type { GetPortInput } from "get-port-please";
+import type { WebSocketHooks } from "crossws";
 
 export interface Certificate {
   key: string;
@@ -52,6 +53,18 @@ export interface ListenOptions {
    * Open a tunnel using https://github.com/unjs/untun
    */
   tunnel?: boolean;
+  /**
+   * WebSocket Upgrade Handler
+   *
+   * Input can be an upgrade handler or CrossWS options
+   *
+   * @experimental CrossWS usage is subject to change
+   * @see https://github.com/unjs/crossws
+   */
+  ws?:
+    | boolean
+    | Partial<WebSocketHooks>
+    | ((req: IncomingMessage, head: Buffer) => void);
 }
 
 export type GetURLOptions = Pick<


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds experimental WebSocket support.

The new `ws` option can be enabled via options or CLI. When set via options and is a function, will be used as normal Node.js upgrade handler.

When is an object, listhen will use [crossws](https://github.com/unjs/crossws) API to listen on the hooks.

When is `true` (set by CLI), listhen dev server will support WebSocket with HMR (using a hooks proxy) 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
