### PR TITLE
docs: add jsdocs for exported functions and types

### DIFF
--- a/src/listen.ts
+++ b/src/listen.ts
@@ -35,6 +35,16 @@ import { resolveCertificate } from "./_cert";
 import { isWsl } from "./lib/wsl";
 import { isDocker } from "./lib/docker";
 
+/**
+ * Starts an HTTP or HTTPS server with the provided request handler and configuration options.
+ * This function sets up the server, configures the port and hostname, enables HTTPS if specified, sets up
+ * WebSocket support if required, handles tunneling for public access, and provides utilities for displaying URLs
+ * and handling server shutdown.
+ *
+ * @param handle The request listener function for handling HTTP requests.
+ * @param _options Partial configuration options for the server. Inherits from {@link ListenOptions}.
+ * @returns a promise that resolves to a {@link Listener} object containing server details and utility functions.
+ */
 export async function listen(
   handle: RequestListener,
   _options: Partial<ListenOptions> = {},

--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -8,12 +8,44 @@ import type { CrossWSOptions, ListenOptions } from "../types";
 import { createResolver } from "./_resolver";
 
 export interface DevServerOptions {
+  /**
+   * The current working directory from which the server should serve files.
+   * @optional
+   * @default process.cwd() || import.meta.url
+   */
   cwd?: string;
+
+  /**
+   * An array of directories from which static files will be served.
+   * @optional
+   * @default ["public"]
+   */
   staticDirs?: string[];
+
+  /**
+   * The logger instance to be used by the development server. See {@link ConsolaInstance}.
+   * @optional
+   * @default consola.withTag("listhen")
+   */
   logger?: ConsolaInstance;
+
+  /**
+   * Configuration options for WebSocket communication. See {@link ListenOptions["ws"]}.
+   * @optional
+   */
   ws?: ListenOptions["ws"];
 }
 
+/**
+ * Creates and configures a development server with options for serving static files,
+ * WebSocket support and custom logging.
+ * 
+ * @param entry The path to the server's entry file.
+ * @param options Configuration options for the development server. See {@link DevServerOptions}.
+ * @returns an object containing server configuration details such as the current working directory (`cwd`),
+ * a resolver function, the node listener function for integration with other Node.js servers or middleware,
+ * a reload function to reload the server configuration, and WebSocket options (`_ws`).
+ */
 export async function createDevServer(
   entry: string,
   options: DevServerOptions,

--- a/src/server/watcher.ts
+++ b/src/server/watcher.ts
@@ -7,12 +7,43 @@ import { listen } from "../listen";
 import { createDevServer, DevServerOptions } from "./dev";
 
 export interface WatchOptions extends DevServerOptions {
+  /**
+   * The current working directory from which the server should run.
+   * Inherits all the properties of {@link DevServerOptions}.
+   * @optional
+   */
   cwd?: string;
+
+  /**
+   * The logger instance to use for logging within the watch process.
+   * @optional
+   * See {@link ConsolaInstance}.
+   */
   logger?: ConsolaInstance;
+
+  /**
+   * An array of glob patterns to specify files or directories to ignore during monitoring.
+   * @optional
+   */
   ignore?: string[];
+
+  /**
+   * An array of directories containing static files. These directories are served by the dev server.
+   * @optional
+   */
   publicDirs?: string[];
 }
 
+/**
+ * Initialises a development server with file-watching capabilities, automatically reloading the server as files change.
+ * This feature combines the setup of a development server with file monitoring to provide a live development environment.
+ * 
+ * @param entry The path to the server's entry file.
+ * @param options Configuration options that combine {@link ListenOptions} and {@link WatchOptions} for server listening and file and
+ * file-watching behaviour. This allows partial customisation by merging server and watcher configurations.
+ * @returns a promise that resolves to an {@link listener} instance representing the launched server with attached file-watching capabilities.
+ * This server will be reloaded on specified file changes.
+ */
 export async function listenAndWatch(
   entry: string,
   options: Partial<ListenOptions & WatchOptions>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,33 +7,135 @@ import type { NodeOptions } from "crossws/adapters/node";
 export type CrossWSOptions = NodeOptions;
 
 export interface Certificate {
+  /**
+   * Private key for HTTPS encryption.
+   */
   key: string;
+
+  /**
+   * Certificate for HTTPS encryption.
+   */
   cert: string;
+
+  /**
+   * Passphrase for accessing the private key, if required.
+   * @optional
+   */
   passphrase?: string;
 }
 
 export interface HTTPSOptions {
+  /**
+   * Path to the SSL certificate file.
+   * @optional
+   */
   cert?: string;
+  
+  /**
+   * Path to the SSL key file.
+   * @optional
+   */
   key?: string;
+
+  /**
+   * Path to a PFX file containing the private key, certificate, and CA certificates.
+   * @optional
+   */
   pfx?: string;
+
+  /**
+   * Passphrase for accessing the private key or PFX file.
+   * @optional
+   */
   passphrase?: string;
+
+  /**
+   * Number of days the self-signed certificate is valid.
+   * @optional
+   * @default 1
+   */
   validityDays?: number;
+
+  /**
+   * Array of domains to include in a self-signed certificate. Required when generating a self-signed certificate.
+   * @optional
+   */
   domains?: string[];
 }
 
 export interface ListenOptions {
+  /**
+   * Unique name for the listener, used for logging and identification purposes.
+   * @default ""
+   */
   name: string;
+
+  /**
+   * The port number or port discovery strategy to use for the server.
+   * @default env.PORT || 3000
+   */
   port: GetPortInput;
+
+  /**
+   * The hostname or IP address to bind the server to.
+   * @default env.HOST || "localhost"
+   */
   hostname: string;
+
+  /**
+   * Whether to display the base URL in logs.
+   * @default true
+   */
   showURL: boolean;
+  
+  /**
+   * The base URL path to prepend to all routes.
+   * @default "/"
+   */
   baseURL: string;
+
+  /**
+   * Whether to automatically open the browser to the base URL when the server starts.
+   * @default false
+   */
   open: boolean;
+
+  /**
+   * Enable HTTPS. Can be a boolean flag or a detailed HTTPS configuration.
+   * @default false
+   */
   https: boolean | HTTPSOptions;
+
+  /**
+   * Whether to copy the base URL to the clipboard when the server starts.
+   * @default false
+   */
   clipboard: boolean;
+
+  /**
+   * Indicates whether the server is running in a test environment.
+   * @default env.NODE_ENV === "test"
+   */
   isTest: boolean;
+
+  /**
+   * Indicates whether the server is running in a production environment.
+   * @default env.NODE_ENV === "production"
+   */
   isProd: boolean;
+
+ /**
+   * Whether to automatically close the server on `SIGINT` and `SIGTERM` signals.
+   * @default true
+   */
   autoClose: boolean;
+
+  /**
+   * The entry point file path for the server, used internally.
+   * @optional
+   */
   _entry?: string;
+
   /**
    * Used as main public url to display
    * @default The first public IPV4 address listening to
@@ -80,17 +182,60 @@ export type ShowURLOptions = Pick<
 >;
 
 export interface ListenURL {
+  /**
+   * The URL being listened to.
+   */
   url: string;
+
+  /**
+   * The type of URL (local, network, or tunnel).
+   */
   type: "local" | "network" | "tunnel";
 }
 
 export interface Listener {
+  /**
+   * The primary URL for accessing the server.
+   */
   url: string;
+
+  /**
+   * The address information of the server. See {@link AddressInfo}.
+   */
   address: AddressInfo;
+
+  /**
+   * The server instance can be either an HTTP or an HTTPS server. See {@link Server} and {@link HTTPServer}.
+   */
   server: Server | HTTPServer;
+
+  /**
+   * Indicates whether HTTPS is enabled and, if so, the certificate details. See {@link Certificate}.
+   */
   https: false | Certificate;
+
+  /**
+   * Closes the server and cleans up resources.
+   */
   close: () => Promise<void>;
+
+  /**
+   * Opens the server URL in your default web browser.
+   */
   open: () => Promise<void>;
+
+  /**
+   * Displays the server URL in the console, with optional appearance configuration.
+   * 
+   * @param options Configuration options for displaying the URL. See {@link ShowURLOptions}.
+   */
   showURL: (options?: ShowURLOptions) => Promise<void>;
+
+  /**
+   * Gets an array of URLs where the server can be reached, based on the options provided.
+   * 
+   * @param options Configuration options for retrieving URLs. See {@link GetURLOptions}.
+   * @returns a promise that resolves to an array of {@link ListenURL} objects.
+   */
   getURLs: (options?: GetURLOptions) => Promise<ListenURL[]>;
 }


### PR DESCRIPTION
Added jsdocs for exported functions and types


### 🔗 Linked issue

N/A

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

> Any feedback is welcomed! 🙌