### PR TITLE
feat: Change open to take a boolean | string

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,10 @@ Show a CLI message for the listening URL.
 
 ### `open`
 
+- Type: string | boolean
 - Default: `false` (force disabled on test and production environments)
 
-Open the URL in the browser. Silently ignores errors.
+Open the URL with an optional supplied relative path in the browser. Silently ignores errors.
 
 ### `clipboard`
 

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -57,6 +57,7 @@ export function generateURL(
   hostname: string,
   listhenOptions: ListenOptions,
   baseURL?: string,
+  relativePath?: string,
 ) {
   const proto = listhenOptions.https ? "https://" : "http://";
   let port = listhenOptions.port || "";
@@ -69,12 +70,16 @@ export function generateURL(
   if (hostname[0] !== "[" && hostname.includes(":")) {
     hostname = `[${hostname}]`;
   }
+  const extraPath =
+    relativePath ||
+    (typeof listhenOptions.open === "string" ? listhenOptions.open : "");
   return (
     proto +
     (hostname || "localhost") +
     ":" +
     port +
-    (baseURL || listhenOptions.baseURL || "")
+    (baseURL || listhenOptions.baseURL || "") +
+    extraPath
   );
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,8 +87,8 @@ export function getArgs() {
       description: "Copy the URL to the clipboard",
     },
     open: {
-      type: "boolean",
-      description: "Open the URL in the browser",
+      description:
+        "Open the URL in the browser. If you specify a string, it will append the value to the URL.",
     },
     https: {
       type: "boolean",
@@ -153,7 +153,8 @@ export function parseArgs(args: ParsedListhenArgs): Partial<ListenOptions> {
     // prettier-ignore
     hostname: typeof args.host === "string" ? args.host : (args.host === true ? "" : undefined),
     clipboard: args.clipboard,
-    open: args.open,
+    // prettier-ignore
+    open: typeof args.open === "string" ? args.open : (typeof args.open === "boolean" ? args.open : false),
     qr: args.qr,
     publicURL: args.publicURL,
     public: args.public,

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -149,8 +149,11 @@ export async function listen(
   }
 
   // --- GetURL Utility ---
-  const getURL = (host = listhenOptions.hostname, baseURL?: string) =>
-    generateURL(host, listhenOptions, baseURL);
+  const getURL = (
+    host = listhenOptions.hostname,
+    baseURL?: string,
+    relativePath?: string,
+  ) => generateURL(host, listhenOptions, baseURL, relativePath);
 
   // --- Start Tunnel ---
   let tunnel: Tunnel | undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,7 @@ export interface ListenOptions {
   hostname: string;
   showURL: boolean;
   baseURL: string;
-  open: boolean;
+  open: boolean | string;
   https: boolean | HTTPSOptions;
   clipboard: boolean;
   isTest: boolean;


### PR DESCRIPTION
Hi again,

this is in response to the Issue I opened #199, I went ahead and implemented it, I hope it looks okay. I was not so sure about how to design some aspects, especially the `getURL` and `generateURL` helper functions.  
If this is not something you wish to implement, feel free to close this PR and the underlying issue ☺️

As it stands, this will do:

- `pnpm listhen .` -> opens nothing
- `pnpm listhen . --open` -> opens the baseURL (e.g. https://localhost:3000/)
- `pnpm listhen . --open myTest` -> opens the baseURL + supplied string (e.g. https://localhost:3000/myTest)

resolves #199 