### PR TITLE
feat: HTTP/2

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage, Server } from "node:http";
-import type { Server as HTTPServer } from "node:https";
+import type { Http2SecureServer } from "node:http2";
 import { AddressInfo } from "node:net";
 import type { GetPortInput } from "get-port-please";
 import type { NodeOptions } from "crossws/adapters/node";
@@ -87,7 +87,7 @@ export interface ListenURL {
 export interface Listener {
   url: string;
   address: AddressInfo;
-  server: Server | HTTPServer;
+  server: Server | Http2SecureServer;
   https: false | Certificate;
   close: () => Promise<void>;
   open: () => Promise<void>;


### PR DESCRIPTION
resolves nuxt/cli#1027

This **should** be a backward compatible change according to [HTTP/2 Compatibility API](https://nodejs.org/api/http2.html#compatibility-api).
However in reality, this may trigger warnings (e.g. setting [response.statusMessage](https://github.com/unjs/httpxy/blob/73d2180e368e80379b6d6681f18e274df1006706/src/middleware/web-outgoing.ts#L132) or [response.setHeader('connection', value)](https://github.com/unjs/httpxy/blob/73d2180e368e80379b6d6681f18e274df1006706/src/middleware/web-outgoing.ts#L114)) or even break some edge case (e.g. [proxy HTTP/2 pseudo header to a HTTP/1 request](https://github.com/unjs/httpxy/blob/73d2180e368e80379b6d6681f18e274df1006706/src/_utils.ts#L48)) if downstream support HTTP/1 only. (p.s. all examples came from httpxy)
So it is open to consider whether this is a break or not.

If this change is acceptable, I will create a fix pr to httpxy later. :wink: