### PR TITLE
feat: support `BROWSER` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,12 @@ Show a CLI message for the listening URL.
 
 Open the URL in the browser. Silently ignores errors.
 
+### `browser`
+
+- Default: `process.env.BROWSER` (and use the system default browser if not specified).
+
+Open the URL in the specified browser.
+
 ### `clipboard`
 
 - Default: `false` (force disabled on test and production environments)

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -287,7 +287,7 @@ export async function listen(
   }
 
   const _open = async () => {
-    await open(getURL()).catch(() => {});
+    await open(getURL(), { browser: process.env.BROWSER }).catch(() => {});
   };
   if (listhenOptions.open) {
     await _open();


### PR DESCRIPTION
resolves https://github.com/unjs/listhen/issues/154

> [!NOTE]
> The current implementation only covers half the features of [`open`](https://github.com/sindresorhus/open#app), and lacks [automatic platform detection for the browser](https://github.com/sindresorhus/open/blob/main/index.js#L301-L368). 
This might not provide a good DX (users have to specify `BROWSER="Google Chrome"` on macOS and `BROWSER=chrome` in Windows). I'm hesitant to port all the implementations due to the large amount of code duplication. 
Instead, should we consider simply using the [`open`](https://github.com/sindresorhus/open#app) package? We could inline it during the build to avoid installing an extra package if that's a concern. WDYT? 🤔
