### PR TITLE
fix: do not use fallback port in production

### DIFF
--- a/src/listen.ts
+++ b/src/listen.ts
@@ -113,7 +113,9 @@ export async function listen(
     port: Number(listhenOptions.port),
     verbose: !listhenOptions.isTest,
     host: listhenOptions.hostname,
-    alternativePortRange: [3000, 3100],
+    ...(listhenOptions.isProd
+      ? { random: false }
+      : { alternativePortRange: [3000, 3100] }),
     public: listhenOptions.public,
     ...(typeof listhenOptions.port === "object" && listhenOptions.port),
   }));

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -29,6 +29,22 @@ describe("listhen", () => {
     expect(listener2.url).toMatch(/:3001\/$/);
     await listener2.close();
   });
+
+  test("should throw in production if port is already in use", async () => {
+    listener = await listen(handle, {
+      port: { port: 3000 },
+      hostname: "localhost",
+    });
+    expect(listener.url).toMatch(/:3000\/$/);
+    await expect(
+      listen(handle, {
+        port: { port: 3000 },
+        hostname: "localhost",
+        isProd: true,
+      }),
+    ).rejects.toThrow(/Unable to find an available port/);
+  });
+
   test("listen (no args)", async () => {
     listener = await listen(handle);
     expect(listener.url.startsWith("http://")).toBe(true);


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

resolves https://github.com/unjs/listhen/issues/222


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Production mode now enforces binding to the requested port; if it’s already in use, the server fails with a clear error instead of switching to another port.
  - Non-production mode retains automatic fallback to an available port within the usual range.
- Tests
  - Added coverage to verify environment-specific behavior when the requested port is occupied, ensuring production errors and non-production falls back as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->