### PR TITLE
fix: filter IPv4 link-local addresses from network interfaces

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -16,6 +16,7 @@ export function getNetworkInterfaces(includeIPV6?: boolean): string[] {
           !d.internal &&
           !(d.mac === "00:00:00:00:00:00") &&
           !d.address.startsWith("fe80::") &&
+          !d.address.startsWith("169.254.") &&
           !(!includeIPV6 && (d.family === "IPv6" || +d.family === 6))
         ) {
           addrs.add(formatAddress(d));


### PR DESCRIPTION
resolves #225 - filter `169.254.x.x` (IPv4 link-local) addresses in `getNetworkInterfaces()`, mirroring the existing `fe80::` filter for IPv6 link-local addresses



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Refined network interface detection to exclude link-local IPv4 addresses, improving the accuracy of interface identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->