### PR TITLE
feat: support `extraURLs` and detect portless by env by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,11 +187,13 @@ Automatically close when an `exit` event, `SIGTERM`, `SIGINT` or `SIGHUP` signal
 
 The public URL to show in the CLI output
 
-### `additionalURLs`
+### `extraURLs`
 
 - Type: `Array<{ title: string, url?: string, env?: string }>`
 
-Additional URLs to show in the CLI output. Use `url` for static links or `env` to resolve the URL from an environment variable when `showURL()` is called.
+Extra URLs to show in the CLI output. Use `url` for a static link or `env` to resolve the URL from an environment variable at `showURL()` time.
+
+By default, `[{ title: "Portless", env: "PORTLESS_URL" }]` is used to surface a Portless URL when present. Pass `extraURLs: []` to disable.
 
 ### `qr`
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ Automatically close when an `exit` event, `SIGTERM`, `SIGINT` or `SIGHUP` signal
 
 The public URL to show in the CLI output
 
+### `additionalURLs`
+
+- Type: `Array<{ title: string, url?: string, env?: string }>`
+
+Additional URLs to show in the CLI output. Use `url` for static links or `env` to resolve the URL from an environment variable when `showURL()` is called.
+
 ### `qr`
 
 - Default: `true`

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -221,8 +221,8 @@ export async function listen(
     }
 
     // Add extra URLs
-    const extraURLs = getURLOptions.extraURLs ||
-      listhenOptions.extraURLs || [{ title: "Portless", env: "PORTLESS_URL" }];
+    const extraURLs = getURLOptions.extraURLs ??
+      listhenOptions.extraURLs ?? [{ title: "Portless", env: "PORTLESS_URL" }];
     for (const extraURL of extraURLs) {
       const url =
         extraURL.url || (extraURL.env ? process.env[extraURL.env] : undefined);

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -208,7 +208,8 @@ export async function listen(
     // Add public URL
     const publicURL =
       getURLOptions.publicURL ||
-      getPublicURL(listhenOptions, getURLOptions.baseURL);
+      getPublicURL(listhenOptions, getURLOptions.baseURL) ||
+      process.env.PORTLESS_URL;
     if (publicURL) {
       _addURL("network", publicURL);
     }

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -198,11 +198,7 @@ export async function listen(
 
     const _addURL = (type: ListenURL["type"], url: string, title?: string) => {
       if (!urls.some((u) => u.url === url)) {
-        urls.push({
-          url,
-          type,
-          ...(title ? { title } : {}),
-        });
+        urls.push({ url, type, title });
       }
     };
 

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -225,9 +225,8 @@ export async function listen(
     }
 
     // Add extra URLs
-    const extraURLs = listhenOptions.extraURLs || [
-      { title: "Portless", env: "PORTLESS_URL" },
-    ];
+    const extraURLs = getURLOptions.extraURLs ||
+      listhenOptions.extraURLs || [{ title: "Portless", env: "PORTLESS_URL" }];
     for (const extraURL of extraURLs) {
       const url =
         extraURL.url || (extraURL.env ? process.env[extraURL.env] : undefined);

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -224,7 +224,8 @@ export async function listen(
     }
 
     // Add additional URLs
-    for (const additionalURL of listhenOptions.additionalURLs || []) {
+    const additionalURLs = listhenOptions.additionalURLs || [{ title: "Portless", env: "PORTLESS_URL" }];
+    for (const additionalURL of additionalURLs) {
       const url =
         additionalURL.url ||
         (additionalURL.env ? process.env[additionalURL.env] : undefined);

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -208,8 +208,7 @@ export async function listen(
     // Add public URL
     const publicURL =
       getURLOptions.publicURL ||
-      getPublicURL(listhenOptions, getURLOptions.baseURL) ||
-      process.env.PORTLESS_URL;
+      getPublicURL(listhenOptions, getURLOptions.baseURL);
     if (publicURL) {
       _addURL("network", publicURL);
     }
@@ -222,6 +221,20 @@ export async function listen(
     // Add tunnel URL
     if (tunnel) {
       _addURL("tunnel", await tunnel.getURL());
+    }
+
+    // Add additional URLs
+    for (const additionalURL of listhenOptions.additionalURLs || []) {
+      const url =
+        additionalURL.url ||
+        (additionalURL.env ? process.env[additionalURL.env] : undefined);
+      if (url) {
+        urls.push({
+          type: "additional",
+          title: additionalURL.title,
+          url,
+        });
+      }
     }
 
     // Add public network interface URLs
@@ -264,14 +277,20 @@ export async function listen(
       );
     }
 
-    const typeMap: Record<ListenURL["type"], [string, ColorName]> = {
+    const typeMap: Record<
+      Exclude<ListenURL["type"], "additional">,
+      [string, ColorName]
+    > = {
       local: ["Local", "green"],
       tunnel: ["Tunnel", "yellow"],
       network: ["Network", "magenta"],
     };
 
     for (const url of urls) {
-      const type = typeMap[url.type];
+      const type =
+        url.type === "additional"
+          ? ([url.title || "URL", "magenta"] as const)
+          : typeMap[url.type];
       const label = getColor(type[1])(
         `  ➜ ${(type[0] + ":").padEnd(8, " ")}${nameSuffix} `,
       );

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -196,11 +196,16 @@ export async function listen(
   const getURLs = async (getURLOptions: GetURLOptions = {}) => {
     const urls: ListenURL[] = [];
 
-    const _addURL = (type: ListenURL["type"], url: string) => {
+    const _addURL = (
+      type: ListenURL["type"],
+      url: string,
+      title?: string,
+    ) => {
       if (!urls.some((u) => u.url === url)) {
         urls.push({
           url,
           type,
+          ...(title ? { title } : {}),
         });
       }
     };
@@ -223,20 +228,16 @@ export async function listen(
       _addURL("tunnel", await tunnel.getURL());
     }
 
-    // Add additional URLs
-    const additionalURLs = listhenOptions.additionalURLs || [
+    // Add extra URLs
+    const extraURLs = listhenOptions.extraURLs || [
       { title: "Portless", env: "PORTLESS_URL" },
     ];
-    for (const additionalURL of additionalURLs) {
+    for (const extraURL of extraURLs) {
       const url =
-        additionalURL.url ||
-        (additionalURL.env ? process.env[additionalURL.env] : undefined);
+        extraURL.url ||
+        (extraURL.env ? process.env[extraURL.env] : undefined);
       if (url) {
-        urls.push({
-          type: "additional",
-          title: additionalURL.title,
-          url,
-        });
+        _addURL("extra", url, extraURL.title);
       }
     }
 
@@ -281,7 +282,7 @@ export async function listen(
     }
 
     const typeMap: Record<
-      Exclude<ListenURL["type"], "additional">,
+      Exclude<ListenURL["type"], "extra">,
       [string, ColorName]
     > = {
       local: ["Local", "green"],
@@ -289,13 +290,17 @@ export async function listen(
       network: ["Network", "magenta"],
     };
 
-    for (const url of urls) {
-      const type =
-        url.type === "additional"
-          ? ([url.title || "URL", "magenta"] as const)
-          : typeMap[url.type];
+    const labels = urls.map((url) =>
+      url.type === "extra"
+        ? ([url.title || "URL", "blue"] as const)
+        : typeMap[url.type],
+    );
+    const labelWidth = Math.max(7, ...labels.map(([name]) => name.length)) + 1;
+
+    for (const [i, url] of urls.entries()) {
+      const type = labels[i];
       const label = getColor(type[1])(
-        `  ➜ ${(type[0] + ":").padEnd(8, " ")}${nameSuffix} `,
+        `  ➜ ${(type[0] + ":").padEnd(labelWidth, " ")}${nameSuffix} `,
       );
       let suffix = "";
       if (url === firstLocalUrl && listhenOptions.clipboard) {

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -196,11 +196,7 @@ export async function listen(
   const getURLs = async (getURLOptions: GetURLOptions = {}) => {
     const urls: ListenURL[] = [];
 
-    const _addURL = (
-      type: ListenURL["type"],
-      url: string,
-      title?: string,
-    ) => {
+    const _addURL = (type: ListenURL["type"], url: string, title?: string) => {
       if (!urls.some((u) => u.url === url)) {
         urls.push({
           url,
@@ -234,8 +230,7 @@ export async function listen(
     ];
     for (const extraURL of extraURLs) {
       const url =
-        extraURL.url ||
-        (extraURL.env ? process.env[extraURL.env] : undefined);
+        extraURL.url || (extraURL.env ? process.env[extraURL.env] : undefined);
       if (url) {
         _addURL("extra", url, extraURL.title);
       }

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -224,7 +224,9 @@ export async function listen(
     }
 
     // Add additional URLs
-    const additionalURLs = listhenOptions.additionalURLs || [{ title: "Portless", env: "PORTLESS_URL" }];
+    const additionalURLs = listhenOptions.additionalURLs || [
+      { title: "Portless", env: "PORTLESS_URL" },
+    ];
     for (const additionalURL of additionalURLs) {
       const url =
         additionalURL.url ||

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,6 +142,10 @@ export interface ListenOptions {
    */
   publicURL?: string;
   /**
+   * Additional URLs to show in the CLI output.
+   */
+  additionalURLs?: AdditionalURL[];
+  /**
    * Print QR Code for public IPv4 address
    *
    * @default true
@@ -181,6 +185,23 @@ export type ShowURLOptions = Pick<
   "baseURL" | "name" | "publicURL" | "qr"
 >;
 
+export interface AdditionalURL {
+  /**
+   * The label shown in the CLI output.
+   */
+  title: string;
+
+  /**
+   * Static URL to show.
+   */
+  url?: string;
+
+  /**
+   * Environment variable that contains the URL to show.
+   */
+  env?: string;
+}
+
 export interface ListenURL {
   /**
    * The URL being listened to.
@@ -188,9 +209,14 @@ export interface ListenURL {
   url: string;
 
   /**
-   * The type of URL (local, network, or tunnel).
+   * Optional custom label for the URL.
    */
-  type: "local" | "network" | "tunnel";
+  title?: string;
+
+  /**
+   * The type of URL (local, network, tunnel, or additional).
+   */
+  type: "local" | "network" | "tunnel" | "additional";
 }
 
 export interface Listener {

--- a/src/types.ts
+++ b/src/types.ts
@@ -177,12 +177,12 @@ export interface ListenOptions {
 
 export type GetURLOptions = Pick<
   Partial<ListenOptions>,
-  "baseURL" | "publicURL"
+  "baseURL" | "publicURL" | "extraURLs"
 >;
 
 export type ShowURLOptions = Pick<
   Partial<ListenOptions>,
-  "baseURL" | "name" | "publicURL" | "qr"
+  "baseURL" | "name" | "publicURL" | "qr" | "extraURLs"
 >;
 
 export interface ExtraURL {

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,9 +142,9 @@ export interface ListenOptions {
    */
   publicURL?: string;
   /**
-   * Additional URLs to show in the CLI output.
+   * Extra URLs to show in the CLI output.
    */
-  additionalURLs?: AdditionalURL[];
+  extraURLs?: ExtraURL[];
   /**
    * Print QR Code for public IPv4 address
    *
@@ -185,7 +185,7 @@ export type ShowURLOptions = Pick<
   "baseURL" | "name" | "publicURL" | "qr"
 >;
 
-export interface AdditionalURL {
+export interface ExtraURL {
   /**
    * The label shown in the CLI output.
    */
@@ -214,9 +214,9 @@ export interface ListenURL {
   title?: string;
 
   /**
-   * The type of URL (local, network, tunnel, or additional).
+   * The type of URL (local, network, tunnel, or extra).
    */
-  type: "local" | "network" | "tunnel" | "additional";
+  type: "local" | "network" | "tunnel" | "extra";
 }
 
 export interface Listener {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -169,31 +169,43 @@ describe("listhen", () => {
   });
 
   describe("public urls", () => {
-    test("includes PORTLESS_URL as a fallback public url", async () => {
+    test("includes additional env-backed urls", async () => {
+      listener = await listen(handle, {
+        hostname: "localhost",
+        additionalURLs: [{ title: "Portless", env: "PORTLESS_URL" }],
+      });
+
       process.env.PORTLESS_URL = "https://app.portless.dev";
-      listener = await listen(handle, { hostname: "localhost" });
 
       expect(await listener.getURLs()).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            type: "network",
+            type: "additional",
+            title: "Portless",
             url: "https://app.portless.dev",
           }),
         ]),
       );
     });
 
-    test("prefers explicit publicURL over PORTLESS_URL", async () => {
+    test("prefers explicit additional url over env fallback", async () => {
       process.env.PORTLESS_URL = "https://fallback.portless.dev";
       listener = await listen(handle, {
         hostname: "localhost",
-        publicURL: "https://configured.example.com",
+        additionalURLs: [
+          {
+            title: "Portless",
+            url: "https://configured.example.com",
+            env: "PORTLESS_URL",
+          },
+        ],
       });
 
       expect(await listener.getURLs()).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            type: "network",
+            type: "additional",
+            title: "Portless",
             url: "https://configured.example.com",
           }),
         ]),

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -17,6 +17,7 @@ describe("listhen", () => {
       await listener.close();
       listener = undefined;
     }
+    delete process.env.PORTLESS_URL;
   });
   test("should listen to the next port in range (3000 -> 31000)", async () => {
     listener = await listen(handle, {
@@ -164,6 +165,46 @@ describe("listhen", () => {
         port: { port: 50_000, portRange: [50_000, 59_999] },
       });
       expect(listener.url).toMatch(/:5\d{4}\/$/);
+    });
+  });
+
+  describe("public urls", () => {
+    test("includes PORTLESS_URL as a fallback public url", async () => {
+      process.env.PORTLESS_URL = "https://app.portless.dev";
+      listener = await listen(handle, { hostname: "localhost" });
+
+      expect(await listener.getURLs()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "network",
+            url: "https://app.portless.dev",
+          }),
+        ]),
+      );
+    });
+
+    test("prefers explicit publicURL over PORTLESS_URL", async () => {
+      process.env.PORTLESS_URL = "https://fallback.portless.dev";
+      listener = await listen(handle, {
+        hostname: "localhost",
+        publicURL: "https://configured.example.com",
+      });
+
+      expect(await listener.getURLs()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "network",
+            url: "https://configured.example.com",
+          }),
+        ]),
+      );
+      expect(await listener.getURLs()).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            url: "https://fallback.portless.dev",
+          }),
+        ]),
+      );
     });
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -168,19 +168,20 @@ describe("listhen", () => {
     });
   });
 
-  describe("public urls", () => {
-    test("includes additional env-backed urls", async () => {
+  describe("extra urls", () => {
+    test("includes env-backed urls (resolved at getURLs time)", async () => {
       listener = await listen(handle, {
         hostname: "localhost",
-        additionalURLs: [{ title: "Portless", env: "PORTLESS_URL" }],
+        extraURLs: [{ title: "Portless", env: "PORTLESS_URL" }],
       });
 
+      // Set after listen() to confirm env is resolved lazily on getURLs()
       process.env.PORTLESS_URL = "https://app.portless.dev";
 
       expect(await listener.getURLs()).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            type: "additional",
+            type: "extra",
             title: "Portless",
             url: "https://app.portless.dev",
           }),
@@ -188,11 +189,11 @@ describe("listhen", () => {
       );
     });
 
-    test("prefers explicit additional url over env fallback", async () => {
+    test("prefers explicit url over env fallback", async () => {
       process.env.PORTLESS_URL = "https://fallback.portless.dev";
       listener = await listen(handle, {
         hostname: "localhost",
-        additionalURLs: [
+        extraURLs: [
           {
             title: "Portless",
             url: "https://configured.example.com",
@@ -201,22 +202,35 @@ describe("listhen", () => {
         ],
       });
 
-      expect(await listener.getURLs()).toEqual(
+      const urls = await listener.getURLs();
+      expect(urls).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            type: "additional",
+            type: "extra",
             title: "Portless",
             url: "https://configured.example.com",
           }),
         ]),
       );
-      expect(await listener.getURLs()).not.toEqual(
+      expect(urls).not.toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             url: "https://fallback.portless.dev",
           }),
         ]),
       );
+    });
+
+    test("does not duplicate an extra url that matches an existing one", async () => {
+      const shared = "https://shared.example.com";
+      listener = await listen(handle, {
+        hostname: "localhost",
+        publicURL: shared,
+        extraURLs: [{ title: "Same", url: shared }],
+      });
+
+      const urls = await listener.getURLs();
+      expect(urls.filter((u) => u.url === shared).length).toBe(1);
     });
   });
 });


### PR DESCRIPTION
Adds a generic `extraURLs` option for showing integration-managed URLs in listhen output, including env-backed values for cases where the URL is only known at runtime.

resolves #227.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Display multiple titled "extra" URLs in CLI output, each with its own label, color, and aligned spacing.

* **Behavior Changes**
  * Extra URLs may be provided as static values or as env-key references resolved when URLs are shown; static values override env lookups.
  * Duplicate URLs are deduplicated in the displayed list.

* **Documentation**
  * Added docs for the extra-URLs option.

* **Tests**
  * Added tests for env-backed resolution, overrides, lazy resolution, and deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->