### PR TITLE
feat: add strictPort option to disable auto port finding

### DIFF
--- a/src/listen.ts
+++ b/src/listen.ts
@@ -113,9 +113,9 @@ export async function listen(
     port: Number(listhenOptions.port),
     verbose: !listhenOptions.isTest,
     host: listhenOptions.hostname,
-    ...(listhenOptions.isProd
-      ? { random: false }
-      : { alternativePortRange: [3000, 3100] }),
+    ...(listhenOptions.strictPort || listhenOptions.isProd
+      ? { random: false, alternativePortRange: [] as const }
+      : { alternativePortRange: [3000, 3100] as const }),
     public: listhenOptions.public,
     ...(typeof listhenOptions.port === "object" && listhenOptions.port),
   }));

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,6 +157,15 @@ export interface ListenOptions {
    * @default `false` for development and `true` for production
    */
   public: boolean;
+
+  /**
+   * If true, fail when the specified port is already in use instead of
+   * automatically trying the next available port.
+   *
+   * @default false
+   */
+  strictPort?: boolean;
+
   /**
    * Open a tunnel using https://github.com/unjs/untun
    */

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -46,6 +46,21 @@ describe("listhen", () => {
     ).rejects.toThrow(/Unable to find an available port/);
   });
 
+  test("should throw with strictPort if port is already in use", async () => {
+    listener = await listen(handle, {
+      port: { port: 3000 },
+      hostname: "localhost",
+    });
+    expect(listener.url).toMatch(/:3000\/$/);
+    await expect(
+      listen(handle, {
+        port: { port: 3000 },
+        hostname: "localhost",
+        strictPort: true,
+      }),
+    ).rejects.toThrow(/Unable to find an available port/);
+  });
+
   test("listen (no args)", async () => {
     listener = await listen(handle);
     expect(listener.url.startsWith("http://")).toBe(true);


### PR DESCRIPTION
## Summary

- Adds `strictPort` to `ListenOptions` to fail fast when the requested port is unavailable
- When enabled, passes `random: false` and `alternativePortRange: []` to `get-port-please` (same behavior as production mode)

Closes #224

## Test plan

- [x] `pnpm test`
- [x] `pnpm lint`
- [x] Added test verifying `strictPort: true` throws when port 3000 is already in use