### PR TITLE
build: make `@parcel/watcher` optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,15 @@
     "release": "pnpm test && pnpm build && changelogen --release && pnpm publish && git push --follow-tags",
     "test": "pnpm lint && vitest run --coverage"
   },
+  "peerDependencies": {
+    "@parcel/watcher": "^2.5.6"
+  },
+  "peerDependenciesMeta": {
+    "@parcel/watcher": {
+      "optional": true
+    }
+  },
   "dependencies": {
-    "@parcel/watcher": "^2.5.6",
     "@parcel/watcher-wasm": "^2.5.6",
     "citty": "^0.2.2",
     "consola": "^3.4.2",


### PR DESCRIPTION
Partially resolves https://github.com/unjs/listhen/issues/238

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package installation requirements to make the native file-watching component optional.
  * Added the WebAssembly-based watcher as the default bundled option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->